### PR TITLE
Feature/new api

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,37 +24,52 @@ yarn add react-floatybox
 ### Basic
 
 ```js
+import React from 'react';
+import {useCallback} from 'react';
 import FloatyBox from 'react-floatybox';
 
-const Tooltip = (props) => <div>I am a tooltip</div>;
-
 const Basic = (props) => {
-    return <FloatyBox open="hover" bubble={Tooltip}>hover over me!</FloatyBox>;
+
+    let tooltip = useCallback(() => {
+        return <div>I am a tooltip</div>;
+    }, []);
+
+    return <FloatyBox open="hover" bubble={tooltip}>hover over me!</FloatyBox>;
 };
 ```
 
 ### With a tail
 
 ```js
+import React from 'react';
+import {useCallback} from 'react';
 import FloatyBox from 'react-floatybox';
 import Point from 'react-floatybox/Point';
 
-const Tooltip = (props) => <div>I am a tooltip <Point {...props.tailProps} color="#000" /></div>;
-
 const WithTail = (props) => {
-    return <FloatyBox open="hover" bubble={Tooltip} tailSize={20}>hover over me!</FloatyBox>
+
+    let tooltip = useCallback(({tailProps}) => {
+        return <div>I am a tooltip <Point {...tailProps} color="#000" /></div>;
+    }, []);
+
+    return <FloatyBox open="hover" bubble={tooltip} tailSize={20}>hover over me!</FloatyBox>
 };
 ```
 
 ### Alignment
 
 ```js
+import React from 'react';
+import {useCallback} from 'react';
 import FloatyBox from 'react-floatybox';
 
-const Tooltip = (props) => <div>I am a thing</div>;
-
 const Basic = (props) => {
-    return <FloatyBox open="click" align="lt" bubble={Tooltip}>click me!</FloatyBox>;
+
+    let tooltip = useCallback(() => {
+        return <div>I am a thing</div>;
+    }, []);
+
+    return <FloatyBox open="click" align="lt" bubble={tooltip}>click me!</FloatyBox>;
 };
 ```
 
@@ -65,9 +80,26 @@ const Basic = (props) => {
 ### Required
 
 #### bubble
-`React.Component`
+`({close, isOpen, tailProps}) => React.Node`
 
-The component to render as a floaty box.
+A function for FloatyBox to call to render the floaty box.
+It's recommended you wrap this in a `useCallback` hook to improve rendering performance.
+The function is passed an object with a few properties:
+
+##### close
+`() => void`
+
+A function that can be called from inside the bubble to close itself.
+
+##### isOpen
+`boolean`
+
+A boolean indicating if the bubble is open.
+
+##### tailProps
+`{side: string, size: number, style: Object}`
+
+An object that can be spread onto a tail component such as `react-floatybox/Point`.
 
 #### children
 `React.Node`
@@ -145,27 +177,6 @@ If provided, FloatyBox won't keep its own state and will just be open when this 
 
 If provided along with `isOpen`, this will be called when FloatyBox wants to change state.
 
-## Props passed to bubble
-
-### close
-`() => void`
-
-A function that can be called from inside the bubble to close itself.
-
-### isOpen
-`boolean`
-
-A boolean indicating if the bubble is open.
-
-### tailProps
-`{side: string, size: number, style: Object}`
-
-An object that can be spread onto a tail component such as `react-floatybox/Point`.
-
-### all other props
-
-All props passed to FloatyBox are also passed down to the bubble component.
-
 ## Todo
 
 - Support for animations by adding an option to always render bubble
@@ -173,3 +184,4 @@ All props passed to FloatyBox are also passed down to the bubble component.
 - Ease into new positions, rather than snapping directly
 - Add option to continually update, for when a FloatyBox is inside something that constantly moves
 - Allow `closeOnOutsideClick` and `closeOnEsc` to work when controlling state externally
+- Work out if its possible to not createReact portals until required when using react-useportal

--- a/packages/react-floatybox-docs/src/component/ColorPicker.js
+++ b/packages/react-floatybox-docs/src/component/ColorPicker.js
@@ -2,6 +2,8 @@
 import type {Node} from 'react';
 
 import React from 'react';
+// $FlowFixMe
+import {useCallback} from 'react';
 import FloatyBox from 'react-floatybox';
 import Point from 'react-floatybox/Point';
 import styled from 'styled-components';
@@ -11,21 +13,36 @@ type Props = {
     onChange: (color: string) => void
 };
 
+let colors = ['#F00', '#F60', '#FF0', '#0F0', '#0FF', '#06F', '#F0F'];
+
 export default (props: Props): Node => {
-    let color = props.value;
+    let currentColor = props.value;
+
+    let bubble = useCallback(({tailProps, close}) => {
+        return <ColorPickerBubble>
+            {colors.map((color, key) => <ColorPickerSquare
+                key={key}
+                color={color}
+                selected={color === currentColor}
+                onClick={() => {
+                    props.onChange(color);
+                    close();
+                }}
+            />)}
+            <Point {...tailProps} color="#EEE" />
+        </ColorPickerBubble>;
+    }, [currentColor, props.onChange]);
 
     // all props passed to FloatyBox are passed down to the bubble component
     // including props that FloatyBox doesn't use like onChange
     return <FloatyBox
         open="click"
-        bubble={ColorPickerBubble}
+        bubble={bubble}
         align="tc"
         tailSize={20}
         gap={25}
-        color={color}
-        onChange={props.onChange}
     >
-        <ColorPickerInput color={color}>color picker??</ColorPickerInput>
+        <ColorPickerInput color={currentColor}>color picker??</ColorPickerInput>
     </FloatyBox>;
 };
 
@@ -36,21 +53,7 @@ const ColorPickerInput = styled.span`
     background-color: ${props => props.color};
 `;
 
-const ColorPickerBubble = styled((props) => {
-    let colors = ['#F00', '#F60', '#FF0', '#0F0', '#0FF', '#06F', '#F0F'];
-    return <div className={props.className}>
-        {colors.map((color, key) => <ColorPickerSquare
-            key={key}
-            color={color}
-            selected={color === props.color}
-            onClick={() => {
-                props.onChange(color);
-                props.close();
-            }}
-        />)}
-        <Point {...props.tailProps} color="#EEE" />
-    </div>;
-})`
+const ColorPickerBubble = styled.div`
     background-color: #EEE;
     padding: .5rem;
 `;

--- a/packages/react-floatybox-docs/src/pages/index.js
+++ b/packages/react-floatybox-docs/src/pages/index.js
@@ -2,6 +2,8 @@
 import React from 'react';
 // $FlowFixMe
 import {useState} from 'react';
+// $FlowFixMe
+import {useCallback} from 'react';
 import Page from 'component/Page';
 import {H2} from 'dcme-style';
 import {Box} from 'dcme-style/layout';
@@ -14,19 +16,7 @@ import Point from 'react-floatybox/Point';
 
 import ColorPicker from '../component/ColorPicker';
 
-const Tooltip = styled((props) => <div className={props.className}>Hello I'm a tooltip.</div>)`
-    background-color: #000;
-    color: #FFF;
-    padding: 1rem;
-`;
-
-const TooltipWithTail = styled((props) => <div className={props.className}>Hello I'm a tooltip. <Point {...props.tailProps} color="#000" /></div>)`
-    background-color: #000;
-    color: #FFF;
-    padding: 1rem;
-`;
-
-const ClosableTooltip = styled((props) => <div className={props.className}>Tooltip <Wow onClick={() => props.close()}>[x]</Wow>.</div>)`
+const Tooltip = styled.div`
     background-color: #000;
     color: #FFF;
     padding: 1rem;
@@ -44,6 +34,18 @@ export default () => {
     // state for color picker example
     let [color, setColor] = useState('#F00');
 
+    let tooltip = useCallback(() => {
+        return <Tooltip>Hello I'm a tooltip.</Tooltip>;
+    }, []);
+
+    let tooltipWithTail = useCallback(({tailProps}) => {
+        return <Tooltip>Hello I'm a tooltip. <Point {...tailProps} color="#000" /></Tooltip>;
+    }, []);
+
+    let closableTooltip = useCallback(({close}) => {
+        return <Tooltip>Tooltip <Wow onClick={close}>[x]</Wow>.</Tooltip>;
+    }, []);
+
     return <Page>
         <Box pt={[3,4]} px={[3,4]} pb="100rem" maxWidth="800px" margin="0 auto">
             <Box mb={4}>
@@ -53,46 +55,46 @@ export default () => {
                 <Text textStyle="monospace">See also <Link to="/dimensions">react-use-real-dimensions</Link></Text>
             </Box>
             <Box mb={4}>
-                <Text>A nice normal day, but then, <FloatyBox open="click" bubble={Tooltip}><Wow>click me!</Wow></FloatyBox> or <FloatyBox open="hover" bubble={Tooltip}><Wow>hover over me!</Wow></FloatyBox></Text>
+                <Text>A nice normal day, but then, <FloatyBox open="click" bubble={tooltip}><Wow>click me!</Wow></FloatyBox> or <FloatyBox open="hover" bubble={tooltip}><Wow>hover over me!</Wow></FloatyBox></Text>
             </Box>
             <Box mb={4}>
-                <Text>Do you like tails? Why not <FloatyBox open="click" bubble={TooltipWithTail} tailSize={20}><Wow>add one of ours!</Wow></FloatyBox></Text>
+                <Text>Do you like tails? Why not <FloatyBox open="click" bubble={tooltipWithTail} tailSize={20}><Wow>add one of ours!</Wow></FloatyBox></Text>
             </Box>
             <Box mb={4}>
-                <Text>Pass <Link href="https://github.com/alex-cory/react-useportal">react-useportal</Link> options as props (such as closeOnEsc = false) <FloatyBox open="click" bubble={Tooltip} closeOnEsc={false}><Wow>like this!</Wow></FloatyBox></Text>
+                <Text>Pass <Link href="https://github.com/alex-cory/react-useportal">react-useportal</Link> options as props (such as closeOnEsc = false) <FloatyBox open="click" bubble={tooltip} closeOnEsc={false}><Wow>like this!</Wow></FloatyBox></Text>
             </Box>
             <Box mb={4}>
-                <Text>Control the state yourself <FloatyBox open="click" isOpen={isOpen} onChange={setOpen} bubble={Tooltip}><Wow>like this!</Wow></FloatyBox></Text>
+                <Text>Control the state yourself <FloatyBox open="click" isOpen={isOpen} onChange={setOpen} bubble={tooltip}><Wow>like this!</Wow></FloatyBox></Text>
             </Box>
             <Box mb={4}>
                 <Text>Positioning is easy, just do </Text>
                 <Text>
-                    <FloatyBox open="click" bubble={TooltipWithTail} tailSize={20} align="tl"><Wow>tl</Wow></FloatyBox><Text> or </Text>
-                    <FloatyBox open="click" bubble={TooltipWithTail} tailSize={20} align="tc"><Wow>tc</Wow></FloatyBox><Text> or </Text>
-                    <FloatyBox open="click" bubble={TooltipWithTail} tailSize={20} align="tr"><Wow>tr</Wow></FloatyBox><Text> or </Text>
-                    <FloatyBox open="click" bubble={TooltipWithTail} tailSize={20} align="bl"><Wow>bl</Wow></FloatyBox><Text> or </Text>
-                    <FloatyBox open="click" bubble={TooltipWithTail} tailSize={20} align="bc"><Wow>bc</Wow></FloatyBox><Text> or </Text>
-                    <FloatyBox open="click" bubble={TooltipWithTail} tailSize={20} align="br"><Wow>br</Wow></FloatyBox><Text> or </Text>
-                    <FloatyBox open="click" bubble={TooltipWithTail} tailSize={20} align="lt"><Wow>lt</Wow></FloatyBox><Text> or </Text>
-                    <FloatyBox open="click" bubble={TooltipWithTail} tailSize={20} align="lc"><Wow>lc</Wow></FloatyBox><Text> or </Text>
-                    <FloatyBox open="click" bubble={TooltipWithTail} tailSize={20} align="lb"><Wow>lb</Wow></FloatyBox><Text> or </Text>
-                    <FloatyBox open="click" bubble={TooltipWithTail} tailSize={20} align="rt"><Wow>rt</Wow></FloatyBox><Text> or </Text>
-                    <FloatyBox open="click" bubble={TooltipWithTail} tailSize={20} align="rc"><Wow>rc</Wow></FloatyBox><Text> or </Text>
-                    <FloatyBox open="click" bubble={TooltipWithTail} tailSize={20} align="rb"><Wow>rb</Wow></FloatyBox><Text> or whatever.</Text>
+                    <FloatyBox open="click" bubble={tooltipWithTail} tailSize={20} align="tl"><Wow>tl</Wow></FloatyBox><Text> or </Text>
+                    <FloatyBox open="click" bubble={tooltipWithTail} tailSize={20} align="tc"><Wow>tc</Wow></FloatyBox><Text> or </Text>
+                    <FloatyBox open="click" bubble={tooltipWithTail} tailSize={20} align="tr"><Wow>tr</Wow></FloatyBox><Text> or </Text>
+                    <FloatyBox open="click" bubble={tooltipWithTail} tailSize={20} align="bl"><Wow>bl</Wow></FloatyBox><Text> or </Text>
+                    <FloatyBox open="click" bubble={tooltipWithTail} tailSize={20} align="bc"><Wow>bc</Wow></FloatyBox><Text> or </Text>
+                    <FloatyBox open="click" bubble={tooltipWithTail} tailSize={20} align="br"><Wow>br</Wow></FloatyBox><Text> or </Text>
+                    <FloatyBox open="click" bubble={tooltipWithTail} tailSize={20} align="lt"><Wow>lt</Wow></FloatyBox><Text> or </Text>
+                    <FloatyBox open="click" bubble={tooltipWithTail} tailSize={20} align="lc"><Wow>lc</Wow></FloatyBox><Text> or </Text>
+                    <FloatyBox open="click" bubble={tooltipWithTail} tailSize={20} align="lb"><Wow>lb</Wow></FloatyBox><Text> or </Text>
+                    <FloatyBox open="click" bubble={tooltipWithTail} tailSize={20} align="rt"><Wow>rt</Wow></FloatyBox><Text> or </Text>
+                    <FloatyBox open="click" bubble={tooltipWithTail} tailSize={20} align="rc"><Wow>rc</Wow></FloatyBox><Text> or </Text>
+                    <FloatyBox open="click" bubble={tooltipWithTail} tailSize={20} align="rb"><Wow>rb</Wow></FloatyBox><Text> or whatever.</Text>
                 </Text>
             </Box>
             <Box mb={4}>
                 <Text>Watch how they respond as you resize your browser and as you scroll. If there isn't enough room on one side, the bubble may appear on the other side. Magic!</Text>
             </Box>
             <Box mb={4}>
-                <Text>How about <FloatyBox open="click" bubble={ClosableTooltip}><Wow>closable tooltips?</Wow></FloatyBox></Text>
+                <Text>How about <FloatyBox open="click" bubble={closableTooltip}><Wow>closable tooltips?</Wow></FloatyBox></Text>
             </Box>
             <Box mb={4}>
                 <Text>What about rolling your own <ColorPicker value={color} onChange={(color) => setColor(color)} /></Text>
             </Box>
             <Box mb={4} style={{overflow: 'auto'}}>
                 <Box width="170%">
-                    <Text>Look at how it positions itself correctly inside of scrollable containers: <FloatyBox open="click" bubble={Tooltip}><Wow>click me!</Wow></FloatyBox></Text>
+                    <Text>Look at how it positions itself correctly inside of scrollable containers: <FloatyBox open="click" bubble={tooltip}><Wow>click me!</Wow></FloatyBox></Text>
                 </Box>
             </Box>
         </Box>

--- a/packages/react-floatybox/README.md
+++ b/packages/react-floatybox/README.md
@@ -24,37 +24,52 @@ yarn add react-floatybox
 ### Basic
 
 ```js
+import React from 'react';
+import {useCallback} from 'react';
 import FloatyBox from 'react-floatybox';
 
-const Tooltip = (props) => <div>I am a tooltip</div>;
-
 const Basic = (props) => {
-    return <FloatyBox open="hover" bubble={Tooltip}>hover over me!</FloatyBox>;
+
+    let tooltip = useCallback(() => {
+        return <div>I am a tooltip</div>;
+    }, []);
+
+    return <FloatyBox open="hover" bubble={tooltip}>hover over me!</FloatyBox>;
 };
 ```
 
 ### With a tail
 
 ```js
+import React from 'react';
+import {useCallback} from 'react';
 import FloatyBox from 'react-floatybox';
 import Point from 'react-floatybox/Point';
 
-const Tooltip = (props) => <div>I am a tooltip <Point {...props.tailProps} color="#000" /></div>;
-
 const WithTail = (props) => {
-    return <FloatyBox open="hover" bubble={Tooltip} tailSize={20}>hover over me!</FloatyBox>
+
+    let tooltip = useCallback(({tailProps}) => {
+        return <div>I am a tooltip <Point {...tailProps} color="#000" /></div>;
+    }, []);
+
+    return <FloatyBox open="hover" bubble={tooltip} tailSize={20}>hover over me!</FloatyBox>
 };
 ```
 
 ### Alignment
 
 ```js
+import React from 'react';
+import {useCallback} from 'react';
 import FloatyBox from 'react-floatybox';
 
-const Tooltip = (props) => <div>I am a thing</div>;
-
 const Basic = (props) => {
-    return <FloatyBox open="click" align="lt" bubble={Tooltip}>click me!</FloatyBox>;
+
+    let tooltip = useCallback(() => {
+        return <div>I am a thing</div>;
+    }, []);
+
+    return <FloatyBox open="click" align="lt" bubble={tooltip}>click me!</FloatyBox>;
 };
 ```
 
@@ -65,9 +80,26 @@ const Basic = (props) => {
 ### Required
 
 #### bubble
-`React.Component`
+`({close, isOpen, tailProps}) => React.Node`
 
-The component to render as a floaty box.
+A function for FloatyBox to call to render the floaty box.
+It's recommended you wrap this in a `useCallback` hook to improve rendering performance.
+The function is passed an object with a few properties:
+
+##### close
+`() => void`
+
+A function that can be called from inside the bubble to close itself.
+
+##### isOpen
+`boolean`
+
+A boolean indicating if the bubble is open.
+
+##### tailProps
+`{side: string, size: number, style: Object}`
+
+An object that can be spread onto a tail component such as `react-floatybox/Point`.
 
 #### children
 `React.Node`
@@ -145,27 +177,6 @@ If provided, FloatyBox won't keep its own state and will just be open when this 
 
 If provided along with `isOpen`, this will be called when FloatyBox wants to change state.
 
-## Props passed to bubble
-
-### close
-`() => void`
-
-A function that can be called from inside the bubble to close itself.
-
-### isOpen
-`boolean`
-
-A boolean indicating if the bubble is open.
-
-### tailProps
-`{side: string, size: number, style: Object}`
-
-An object that can be spread onto a tail component such as `react-floatybox/Point`.
-
-### all other props
-
-All props passed to FloatyBox are also passed down to the bubble component.
-
 ## Todo
 
 - Support for animations by adding an option to always render bubble
@@ -173,3 +184,4 @@ All props passed to FloatyBox are also passed down to the bubble component.
 - Ease into new positions, rather than snapping directly
 - Add option to continually update, for when a FloatyBox is inside something that constantly moves
 - Allow `closeOnOutsideClick` and `closeOnEsc` to work when controlling state externally
+- Work out if its possible to not createReact portals until required when using react-useportal

--- a/packages/react-floatybox/src/FloatyBox.jsx
+++ b/packages/react-floatybox/src/FloatyBox.jsx
@@ -237,7 +237,7 @@ const getFloatyStyle = (params) => {
 
             // position tail
             let tailHide = !inRange(pos, edge, maxEdge);
-            let tail = lerp(bubbleSize, -tailSize, axis[side]);
+            let tail = lerp(bubbleSize - 1, -tailSize + 1, axis[side]);
 
             return {
                 pos: clampedPos,

--- a/packages/react-floatybox/src/FloatyBox.jsx
+++ b/packages/react-floatybox/src/FloatyBox.jsx
@@ -16,8 +16,9 @@ import useRealDimensions from 'react-use-real-dimensions';
 type Props = {
     // components
     children: Node,
-    bubble: any,
     wrap: any,
+    // element thunks
+    bubble: (bubbleParams: BubbleParams) => Node,
     // positioning
     align: string,
     gap: number,
@@ -39,6 +40,12 @@ type Portal = {
     ref: {
         current: ?HTMLElement
     }
+};
+
+type BubbleParams = {
+    close: () => any,
+    isOpen: boolean,
+    tailProps: any
 };
 
 const FloatyBox = (props: Props): Node => {
@@ -126,23 +133,32 @@ const FloatyBox = (props: Props): Node => {
         : props.children;
 
     let {Portal} = portal;
-    let Bubble = props.bubble;
+
+    let renderedBubble = useMemo(() => {
+        return props.bubble({
+            close: () => portal.closePortal(),
+            isOpen: portal.isOpen,
+            tailProps: {
+                side: realSide,
+                size: tailSize,
+                style: tailStyle
+            }
+        });
+    }, [
+        props.bubble,
+        realSide,
+        tailSize,
+        tailStyle,
+        portal.isOpen,
+        portal.closePortal
+    ]);
 
     return <>
         {children}
         {portal.isOpen &&
             <Portal>
                 <div style={bubbleStyle} ref={bubbleRef}>
-                    <Bubble
-                        close={() => portal.closePortal()}
-                        isOpen={portal.isOpen}
-                        tailProps={{
-                            side: realSide,
-                            size: tailSize,
-                            style: tailStyle
-                        }}
-                        {...props}
-                    />
+                    {renderedBubble}
                 </div>
             </Portal>
         }


### PR DESCRIPTION
- **BREAKING CHANGE** use thunk for bubble instead of component
  - Turns out bubble contents are nearly always very dependent on data from the parent, and the way I have it now is redux-form v4 style “make a special component every time” lameness. Much nicer to pass data from parent via scope than via an invisible mashing of props.
- fix: rounding errors can break tail away from bubble, compensate for it by pushing it under 1px

```js
// old
const Tooltip = (props) => <div>I am a tooltip</div>;
const Basic = (props) => {
    return <FloatyBox open="hover" bubble={Tooltip}>hover over me!</FloatyBox>;
};

// new
const Basic = (props) => {
    let tooltip = useCallback(() => {
        return <div>I am a tooltip</div>;
    }, []);
    return <FloatyBox open="hover" bubble={tooltip}>hover over me!</FloatyBox>;
};
```