### PR TITLE
break: make side and align use separate props

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ const Basic = (props) => {
         return <div>I am a thing</div>;
     }, []);
 
-    return <FloatyBox open="click" align="lt" bubble={tooltip}>click me!</FloatyBox>;
+    return <FloatyBox open="click" side="top" align="left" bubble={tooltip}>click me!</FloatyBox>;
 };
 ```
 
@@ -114,23 +114,17 @@ It can handle click and hover events to control the open state of the bubble.
 
 If provided, this sets the kind of interaction that will open and close the bubble.
 
+#### side
+`"top"|"bottom"|"left"|"right", default = "top"`
+
+Chooses the preferred side of the anchor that the bubble should appear on.
+
 #### align
-`string (optional), default = "tc"`
+`string (optional), default = "center"`
 
-Sets the preferred positioning of the bubble relative to the anchor. Options are:
-
-- `tl` - top left
-- `tc` - top centre
-- `tr` - top right
-- `bl` - bottom left
-- `bc` - bottom centre
-- `br` - bottom right
-- `lt` - left top
-- `lc` - left centre
-- `lb` - left bottom
-- `rt` - right top
-- `rc` - right centre
-- `rb` - right bottom
+Sets the bubble's preferred perpendicular alignment.
+- When `side` is `"top"` or `"bottom"`, valid values are `"center"`, `"left"` or `"right"`.
+- When `side` is `"left"` or `"right"`, valid values are `"center"`, `"up"` or `"down"`.
 
 ### gap
 `number (optional), default = 10`
@@ -183,5 +177,7 @@ If provided along with `isOpen`, this will be called when FloatyBox wants to cha
 - Option to auto close bubble when anchor moves off screen
 - Ease into new positions, rather than snapping directly
 - Add option to continually update, for when a FloatyBox is inside something that constantly moves
+- Add option to manually update, such as on prop change
 - Allow `closeOnOutsideClick` and `closeOnEsc` to work when controlling state externally
+- Allow multiple floatyboxes to share a tooltip
 - Work out if its possible to not createReact portals until required when using react-useportal

--- a/packages/react-floatybox-docs/src/pages/index.js
+++ b/packages/react-floatybox-docs/src/pages/index.js
@@ -67,20 +67,22 @@ export default () => {
                 <Text>Control the state yourself <FloatyBox open="click" isOpen={isOpen} onChange={setOpen} bubble={tooltip}><Wow>like this!</Wow></FloatyBox></Text>
             </Box>
             <Box mb={4}>
-                <Text>Positioning is easy, just do </Text>
+                <Text>Positioning is easy, just use the <Wow>side</Wow> and <Wow>align</Wow> props.</Text>
+            </Box>
+            <Box mb={4}>
                 <Text>
-                    <FloatyBox open="click" bubble={tooltipWithTail} tailSize={20} align="tl"><Wow>tl</Wow></FloatyBox><Text> or </Text>
-                    <FloatyBox open="click" bubble={tooltipWithTail} tailSize={20} align="tc"><Wow>tc</Wow></FloatyBox><Text> or </Text>
-                    <FloatyBox open="click" bubble={tooltipWithTail} tailSize={20} align="tr"><Wow>tr</Wow></FloatyBox><Text> or </Text>
-                    <FloatyBox open="click" bubble={tooltipWithTail} tailSize={20} align="bl"><Wow>bl</Wow></FloatyBox><Text> or </Text>
-                    <FloatyBox open="click" bubble={tooltipWithTail} tailSize={20} align="bc"><Wow>bc</Wow></FloatyBox><Text> or </Text>
-                    <FloatyBox open="click" bubble={tooltipWithTail} tailSize={20} align="br"><Wow>br</Wow></FloatyBox><Text> or </Text>
-                    <FloatyBox open="click" bubble={tooltipWithTail} tailSize={20} align="lt"><Wow>lt</Wow></FloatyBox><Text> or </Text>
-                    <FloatyBox open="click" bubble={tooltipWithTail} tailSize={20} align="lc"><Wow>lc</Wow></FloatyBox><Text> or </Text>
-                    <FloatyBox open="click" bubble={tooltipWithTail} tailSize={20} align="lb"><Wow>lb</Wow></FloatyBox><Text> or </Text>
-                    <FloatyBox open="click" bubble={tooltipWithTail} tailSize={20} align="rt"><Wow>rt</Wow></FloatyBox><Text> or </Text>
-                    <FloatyBox open="click" bubble={tooltipWithTail} tailSize={20} align="rc"><Wow>rc</Wow></FloatyBox><Text> or </Text>
-                    <FloatyBox open="click" bubble={tooltipWithTail} tailSize={20} align="rb"><Wow>rb</Wow></FloatyBox><Text> or whatever.</Text>
+                    <FloatyBox open="click" bubble={tooltipWithTail} tailSize={20} side="top"><Wow>top</Wow></FloatyBox><Text> or </Text>
+                    <FloatyBox open="click" bubble={tooltipWithTail} tailSize={20} side="top" align="left"><Wow>top / left</Wow></FloatyBox><Text> or </Text>
+                    <FloatyBox open="click" bubble={tooltipWithTail} tailSize={20} side="top" align="right"><Wow>top / right</Wow></FloatyBox><Text> or </Text>
+                    <FloatyBox open="click" bubble={tooltipWithTail} tailSize={20} side="bottom"><Wow>bottom</Wow></FloatyBox><Text> or </Text>
+                    <FloatyBox open="click" bubble={tooltipWithTail} tailSize={20} side="bottom" align="left"><Wow>bottom / left</Wow></FloatyBox><Text> or </Text>
+                    <FloatyBox open="click" bubble={tooltipWithTail} tailSize={20} side="bottom" align="right"><Wow>bottom / right</Wow></FloatyBox><Text> or </Text>
+                    <FloatyBox open="click" bubble={tooltipWithTail} tailSize={20} side="left"><Wow>left</Wow></FloatyBox><Text> or </Text>
+                    <FloatyBox open="click" bubble={tooltipWithTail} tailSize={20} side="left" align="up"><Wow>left / up</Wow></FloatyBox><Text> or </Text>
+                    <FloatyBox open="click" bubble={tooltipWithTail} tailSize={20} side="left" align="down"><Wow>left / down</Wow></FloatyBox><Text> or </Text>
+                    <FloatyBox open="click" bubble={tooltipWithTail} tailSize={20} side="right"><Wow>right</Wow></FloatyBox><Text> or </Text>
+                    <FloatyBox open="click" bubble={tooltipWithTail} tailSize={20} side="right" align="up"><Wow>right / up</Wow></FloatyBox><Text> or </Text>
+                    <FloatyBox open="click" bubble={tooltipWithTail} tailSize={20} side="right" align="down"><Wow>right / down</Wow></FloatyBox><Text> or whatever.</Text>
                 </Text>
             </Box>
             <Box mb={4}>

--- a/packages/react-floatybox/README.md
+++ b/packages/react-floatybox/README.md
@@ -69,7 +69,7 @@ const Basic = (props) => {
         return <div>I am a thing</div>;
     }, []);
 
-    return <FloatyBox open="click" align="lt" bubble={tooltip}>click me!</FloatyBox>;
+    return <FloatyBox open="click" side="top" align="left" bubble={tooltip}>click me!</FloatyBox>;
 };
 ```
 
@@ -114,23 +114,17 @@ It can handle click and hover events to control the open state of the bubble.
 
 If provided, this sets the kind of interaction that will open and close the bubble.
 
+#### side
+`"top"|"bottom"|"left"|"right", default = "top"`
+
+Chooses the preferred side of the anchor that the bubble should appear on.
+
 #### align
-`string (optional), default = "tc"`
+`string (optional), default = "center"`
 
-Sets the preferred positioning of the bubble relative to the anchor. Options are:
-
-- `tl` - top left
-- `tc` - top centre
-- `tr` - top right
-- `bl` - bottom left
-- `bc` - bottom centre
-- `br` - bottom right
-- `lt` - left top
-- `lc` - left centre
-- `lb` - left bottom
-- `rt` - right top
-- `rc` - right centre
-- `rb` - right bottom
+Sets the bubble's preferred perpendicular alignment.
+- When `side` is `"top"` or `"bottom"`, valid values are `"center"`, `"left"` or `"right"`.
+- When `side` is `"left"` or `"right"`, valid values are `"center"`, `"up"` or `"down"`.
 
 ### gap
 `number (optional), default = 10`
@@ -183,5 +177,7 @@ If provided along with `isOpen`, this will be called when FloatyBox wants to cha
 - Option to auto close bubble when anchor moves off screen
 - Ease into new positions, rather than snapping directly
 - Add option to continually update, for when a FloatyBox is inside something that constantly moves
+- Add option to manually update, such as on prop change
 - Allow `closeOnOutsideClick` and `closeOnEsc` to work when controlling state externally
+- Allow multiple floatyboxes to share a tooltip
 - Work out if its possible to not createReact portals until required when using react-useportal

--- a/packages/react-floatybox/src/FloatyBox.jsx
+++ b/packages/react-floatybox/src/FloatyBox.jsx
@@ -20,7 +20,8 @@ type Props = {
     // element thunks
     bubble: (bubbleParams: BubbleParams) => Node,
     // positioning
-    align: string,
+    side: "top"|"bottom"|"left"|"right",
+    align: "up"|"down"|"left"|"right"|"center",
     gap: number,
     edge: number,
     zIndex: number,
@@ -50,8 +51,17 @@ type BubbleParams = {
 
 const FloatyBox = (props: Props): Node => {
 
-    let [side, align] = props.align.split('');
+    let getSideAlignLetter = (str: string): string => {
+        str = str[0];
+        if(str === 'u') return 't';
+        if(str === 'd') return 'b';
+        return str;
+    };
+
     let {gap, edge, tailSize} = props;
+    let side = getSideAlignLetter(props.side);
+    let align = getSideAlignLetter(props.align);
+
 
     let isControlled = typeof props.isOpen === 'boolean';
 
@@ -166,7 +176,8 @@ const FloatyBox = (props: Props): Node => {
 };
 
 FloatyBox.defaultProps = {
-    align: 'tc',
+    side: 'top',
+    align: 'center',
     gap: 10,
     edge: 10,
     wrap: 'span',


### PR DESCRIPTION
- **BREAKING CHANGE** single `align` prop has been replaced with a `side` prop and an `align` prop, to allow each prop to have individual defaults, and also to better manage confusion once the slightly advanced concept of `innerAlign` is introduced.