### PR TITLE
break: add many alignment options

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A React component for positioning floating components such as tooltips, dropdown
 - Handles all your bubble positioning
 - Avoids screen edges
 - Bubble size and position can be determined automatically, specified widths and heights not required
-- Built in support for positining of tails (those little pointy things at the bottom of tooltips)
+- Built in support for positioning of tails (those little pointy things at the bottom of tooltips)
 - Built in behaviour to open and close via hover or click, and to close via click-outside or ESC key
 - Can use its own state or can be controlled
 - Uses React portals via the [react-useportal](https://github.com/alex-cory/react-useportal) hook

--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@ A React component for positioning floating components such as tooltips, dropdown
 
 * **[See some examples - coming soon](#)**
 
+- [Features](#features)
+- [Installation](#installation)
+- [Usage](#usage)
+- [Props](#props)
+- [Development](#development)
+
 ## Features
 - Handles all your bubble positioning
 - Avoids screen edges
@@ -246,10 +252,9 @@ onChange?: (isOpen: boolean) => void (optional)` // optional
 
 If provided along with `isOpen`, this will be called when FloatyBox wants to change state.
 
-## Todo
+## Development
 
-- Support for animations by adding an option to always render bubble
-- Option to auto close bubble when anchor moves off screen
-- Ease into new positions, rather than snapping directly
-- Allow `closeOnOutsideClick` and `closeOnEsc` to work when controlling state externally
-- Allow multiple floatyboxes to share a tooltip
+React-floatybox is written and maintained by [Damien Clarke](https://damienclarke.me/), with feedback from others at [92green](https://github.com/92green).
+All online library discussion happens over on [Github](https://github.com/92green/react-floatybox).
+
+I hope this library helps solve some React positioning problems for you. 🎉

--- a/README.md
+++ b/README.md
@@ -77,8 +77,20 @@ const Basic = (props) => {
 
 ## Props
 
+### children
+
+```flow
+children: React.Node
+```
+
+The React element that the bubble is tethered to, called the "anchor".
+It can handle click and hover events to control the open state of the bubble.
+
 ### bubble
-`({close, isOpen, tailProps}) => React.Node`
+
+```flow
+bubble: ({close, isOpen, tailProps}) => React.Node
+```
 
 A function for FloatyBox to call to render the floaty box.
 It's recommended you wrap this in a `useCallback` hook to improve rendering performance.
@@ -90,83 +102,147 @@ The function is passed an object with a few properties:
 | **isOpen**    | `boolean`                                     | A boolean indicating if the bubble is open.                                         |
 | **tailProps** | `{side: string, size: number, style: Object}` | An object that can be spread onto a tail component such as `react-floatybox/Point`. |
 
-
-### children
-`React.Node`
-
-The React element that the bubble is tethered to, called the "anchor".
-It can handle click and hover events to control the open state of the bubble.
-
 ### open
-`"click"|"hover"|"always" (optional)`
+
+```flow
+open?: "click"|"hover"|"always" // optional
+```
 
 If provided, this sets the kind of interaction that will open and close the bubble.
 
 ### side
-`"top"|"bottom"|"left"|"right", default = "top"`
+
+```flow
+side: "top"|"bottom"|"left"|"right" = "top"
+```
 
 Chooses the preferred side of the anchor that the bubble should appear on.
 
 ### align
-`string (optional), default = "center"`
 
-Sets the bubble's preferred perpendicular alignment.
+```flow
+align: string = "center"
+```
+
+Sets the bubble's preferred alignment in relation to its tail.
+
+- When `side` is `"top"` or `"bottom"`, valid values are `"center"`, `"left"` or `"right"`.
+- When `side` is `"left"` or `"right"`, valid values are `"center"`, `"up"` or `"down"`.
+
+### alignInner
+
+```flow
+alignInner: string = "center"
+```
+
+Sets the tail's preferred alignment in relation to the anchor.
+
+When building things with small anchors and large bubbles, such as tooltips, this prop is usually best on its default "center" setting. But if your anchor is larger than your bubble then this alignment becomes more useful.
+
 - When `side` is `"top"` or `"bottom"`, valid values are `"center"`, `"left"` or `"right"`.
 - When `side` is `"left"` or `"right"`, valid values are `"center"`, `"up"` or `"down"`.
 
 ### flip
-`boolean, default = false`
+
+```flow
+flip: boolean = false
+```
 
 Set to true to allow FloatyBox to flip the bubble to the opposite side of the anchor if there is not enough space to fit it on the preferred side.
 
+### slide
+
+```flow
+slide: boolean = false
+```
+
+Set to true to allow FloatyBox to slide the bubble across the side of the anchor if there is not enough space to fit it at the preferred alignment.
+
+### trap
+
+```flow
+trap: boolean = false
+```
+
+Trap will prevent the bubble from ever leaving the screen.
+
 ### gap
-`number (optional), default = 10`
+
+```flow
+gap: number = 10
+```
 
 The gap between the bubble and the anchor, in pixels.
 
 ### edge
-`number (optional), default = 10`
+
+```flow
+edge: number = 10
+```
 
 How close the bubble is allowed to be posiitioned near a screen edge, in pixels.
 
 ### zIndex
-`number (optional), default = 100`
+
+```flow
+zIndex: number = 100
+```
 
 The `zIndex` of the bubble element.
 
 ### closeOnOutsideClick
-`boolean (optional), default = true`
+
+```flow
+closeOnOutsideClick: boolean = true
+```
 
 A [react-useportal](https://github.com/alex-cory/react-useportal) option that lets the bubble close when you click outside of it.
 
 ### closeOnEsc
-`boolean (optional), default = true`
+
+```flow
+closeOnEsc: boolean = true
+```
 
 A [react-useportal](https://github.com/alex-cory/react-useportal) option that lets the bubble close when you press the escape key.
 
 ### tailSize
-`number (optional)`
+
+```flow
+tailSize?: number // optional
+```
 
 If a tail is used on your bubble, `tailSize` must be set so FloatyBox can adjust its positioning.
 
 ### wrap
-`React.Component (optional), default = "span"`
+
+```flow
+wrap: React.Component = "span"
+```
 
 The component that the FloatyBox anchor gets wrapped in.
 
 ### forceUpdate
 
-`Array<any> (optional) default = []`
+```flow
+forceUpdate: Array<any> = []
+```
 
 The forceUpdate prop allows you to force the bubble position to update. Pass it an array of values, and when any of these values change then the bubble position will be recalculated.
 
 ### isOpen
-`boolean (optional)`
+
+```flow
+isOpen?: boolean // optional
+```
 
 If provided, FloatyBox won't keep its own state and will just be open when this boolean is `true`.
 
 ### onChange
-`(isOpen: boolean) => void (optional)`
+
+```flow
+onChange?: (isOpen: boolean) => void (optional)` // optional
+```
 
 If provided along with `isOpen`, this will be called when FloatyBox wants to change state.
 
@@ -177,4 +253,3 @@ If provided along with `isOpen`, this will be called when FloatyBox wants to cha
 - Ease into new positions, rather than snapping directly
 - Allow `closeOnOutsideClick` and `closeOnEsc` to work when controlling state externally
 - Allow multiple floatyboxes to share a tooltip
-- Work out if its possible to not createReact portals until required when using react-useportal

--- a/packages/react-floatybox-docs/src/component/DragMe.js
+++ b/packages/react-floatybox-docs/src/component/DragMe.js
@@ -26,17 +26,21 @@ import ParcelBoundary from 'react-dataparcels/ParcelBoundary';
 
 const INITIAL_PROPS = {
     props: {
-        open: 'click',
+        open: 'always',
         tailSize: 20,
         side: 'top',
         align: 'center',
+        alignInner: 'center',
         gap: 10,
         edge: 10,
         flip: true,
+        slide: true,
+        trap: false,
         wrap: 'div'
     },
     demo: {
-        big: false
+        big: false,
+        tail: true
     }
 };
 
@@ -67,17 +71,20 @@ export const DragMe = styled((props: any) => {
         beforeChange: (value) => {
             if(!getAlignOptions(value.props.side).includes(value.props.align)) {
                 value.props.align = 'center';
+                value.props.alignInner = 'center';
             }
             return value;
         }
     });
 
     let bubble = useCallback(({tailProps}) => {
-        return <Tooltip>I am a tooltip <Point {...tailProps} color="#000" /></Tooltip>;
-    }, []);
+        return <Tooltip>I am a tooltip {demoParcel.value.demo.tail && <Point {...tailProps} color="#000" />}</Tooltip>;
+    }, [demoParcel.value.demo.tail]);
 
     let floatyBoxProps = {
         ...demoParcel.value.props,
+        gap: Number(demoParcel.value.props.gap),
+        edge: demoParcel.value.props.edge === '' ? undefined : Number(demoParcel.value.props.edge),
         tailSize: Number(demoParcel.value.props.tailSize),
         bubble
     };
@@ -100,8 +107,17 @@ export const DragMe = styled((props: any) => {
                 <ParcelBoundary parcel={demoParcel.getIn(['props','align'])} forceUpdate={[alignOptions]}>
                     {(parcel) => <InputRow label="align"><Select {...parcel.spreadDOM()} options={alignOptions} /></InputRow>}
                 </ParcelBoundary>
+                <ParcelBoundary parcel={demoParcel.getIn(['props','alignInner'])} forceUpdate={[alignOptions]}>
+                    {(parcel) => <InputRow label="alignInner"><Select {...parcel.spreadDOM()} options={alignOptions} /></InputRow>}
+                </ParcelBoundary>
                 <ParcelBoundary parcel={demoParcel.getIn(['props','flip'])}>
                     {(parcel) => <InputRow label="flip"><Checkbox {...parcel.spreadDOMCheckbox()} /></InputRow>}
+                </ParcelBoundary>
+                <ParcelBoundary parcel={demoParcel.getIn(['props','slide'])}>
+                    {(parcel) => <InputRow label="slide"><Checkbox {...parcel.spreadDOMCheckbox()} /></InputRow>}
+                </ParcelBoundary>
+                <ParcelBoundary parcel={demoParcel.getIn(['props','trap'])}>
+                    {(parcel) => <InputRow label="trap"><Checkbox {...parcel.spreadDOMCheckbox()} /></InputRow>}
                 </ParcelBoundary>
                 <ParcelBoundary parcel={demoParcel.getIn(['props','gap'])}>
                     {(parcel) => <InputRow label="gap"><Input type="number" width="100%" {...parcel.spreadDOM()} /></InputRow>}
@@ -118,13 +134,15 @@ export const DragMe = styled((props: any) => {
                 <ParcelBoundary parcel={demoParcel.getIn(['demo','big'])}>
                     {(parcel) => <InputRow label="big"><Checkbox {...parcel.spreadDOMCheckbox()} /></InputRow>}
                 </ParcelBoundary>
+                <ParcelBoundary parcel={demoParcel.getIn(['demo','tail'])}>
+                    {(parcel) => <InputRow label="tail"><Checkbox {...parcel.spreadDOMCheckbox()} /></InputRow>}
+                </ParcelBoundary>
             </Box>
         </Flex>
     </div>;
 })`
     border: 1px dashed ${props => props.theme.colors.line};
     width: 100%;
-    height: 20rem;
     padding: 1rem;
 `;
 

--- a/packages/react-floatybox-docs/src/pages/indexMdx.mdx
+++ b/packages/react-floatybox-docs/src/pages/indexMdx.mdx
@@ -23,7 +23,7 @@ Drag the square around, and try scrolling the square out of view to see how the 
 - Handles all your bubble positioning
 - Avoids screen edges
 - Bubble size and position can be determined automatically, specified widths and heights not required
-- Built in support for positining of tails (those little pointy things at the bottom of tooltips)
+- Built in support for positioning of tails (those little pointy things at the bottom of tooltips)
 - Built in behaviour to open and close via hover or click, and to close via click-outside or ESC key
 - Can use its own state or can be controlled
 - Uses React portals via the [react-useportal](https://github.com/alex-cory/react-useportal) hook

--- a/packages/react-floatybox-docs/src/pages/indexMdx.mdx
+++ b/packages/react-floatybox-docs/src/pages/indexMdx.mdx
@@ -11,8 +11,8 @@ A React component for positioning floating components such as tooltips, dropdown
 
 ## Demo
 
-Here you can test out how different props behave. Click or hover over the bluen square.
-Try scrolling the square out of view while it's open, or drag the square around to see how it moves near the edges of the screen.
+Here you can test out how different props behave.
+Drag the square around, and try scrolling the square out of view to see how the various options make it respond when it's near the edges of the screen.
 
 <DragMe />
 
@@ -143,7 +143,21 @@ Chooses the preferred side of the anchor that the bubble should appear on.
 align: string = "center"
 ```
 
-Sets the bubble's preferred perpendicular alignment.
+Sets the bubble's preferred alignment in relation to its tail.
+
+- When `side` is `"top"` or `"bottom"`, valid values are `"center"`, `"left"` or `"right"`.
+- When `side` is `"left"` or `"right"`, valid values are `"center"`, `"up"` or `"down"`.
+
+### alignInner
+
+```flow
+alignInner: string = "center"
+```
+
+Sets the tail's preferred alignment in relation to the anchor.
+
+When building things with small anchors and large bubbles, such as tooltips, this prop is usually best on its default "center" setting. But if your anchor is larger than your bubble then this alignment becomes more useful.
+
 - When `side` is `"top"` or `"bottom"`, valid values are `"center"`, `"left"` or `"right"`.
 - When `side` is `"left"` or `"right"`, valid values are `"center"`, `"up"` or `"down"`.
 
@@ -155,6 +169,21 @@ flip: boolean = false
 
 Set to true to allow FloatyBox to flip the bubble to the opposite side of the anchor if there is not enough space to fit it on the preferred side.
 
+### slide
+
+```flow
+slide: boolean = false
+```
+
+Set to true to allow FloatyBox to slide the bubble across the side of the anchor if there is not enough space to fit it at the preferred alignment.
+
+### trap
+
+```flow
+trap: boolean = false
+```
+
+Trap will prevent the bubble from ever leaving the screen.
 
 ### gap
 

--- a/packages/react-floatybox-docs/src/pages/indexMdx.mdx
+++ b/packages/react-floatybox-docs/src/pages/indexMdx.mdx
@@ -8,6 +8,7 @@ A React component for positioning floating components such as tooltips, dropdown
 - [Installation](#installation)
 - [Usage](#usage)
 - [Props](#props)
+- [Development](#development)
 
 ## Demo
 
@@ -267,11 +268,9 @@ If provided along with `isOpen`, this will be called when FloatyBox wants to cha
 
 ---
 
-## Todo
+## Development
 
-- Support for animations by adding an option to always render bubble
-- Option to auto close bubble when anchor moves off screen
-- Ease into new positions, rather than snapping directly
-- Allow `closeOnOutsideClick` and `closeOnEsc` to work when controlling state externally
-- Allow multiple floatyboxes to share a tooltip
-- Work out if its possible to not createReact portals until required when using react-useportal
+React-floatybox is written and maintained by [Damien Clarke](https://damienclarke.me/), with feedback from others at [92green](https://github.com/92green).
+All online library discussion happens over on [Github](https://github.com/92green/react-floatybox).
+
+I hope this library helps solve some React positioning problems for you. 🎉

--- a/packages/react-floatybox/README.md
+++ b/packages/react-floatybox/README.md
@@ -8,7 +8,7 @@ A React component for positioning floating components such as tooltips, dropdown
 - Handles all your bubble positioning
 - Avoids screen edges
 - Bubble size and position can be determined automatically, specified widths and heights not required
-- Built in support for positining of tails (those little pointy things at the bottom of tooltips)
+- Built in support for positioning of tails (those little pointy things at the bottom of tooltips)
 - Built in behaviour to open and close via hover or click, and to close via click-outside or ESC key
 - Can use its own state or can be controlled
 - Uses React portals via the [react-useportal](https://github.com/alex-cory/react-useportal) hook

--- a/packages/react-floatybox/README.md
+++ b/packages/react-floatybox/README.md
@@ -4,6 +4,12 @@ A React component for positioning floating components such as tooltips, dropdown
 
 * **[See some examples - coming soon](#)**
 
+- [Features](#features)
+- [Installation](#installation)
+- [Usage](#usage)
+- [Props](#props)
+- [Development](#development)
+
 ## Features
 - Handles all your bubble positioning
 - Avoids screen edges
@@ -246,10 +252,9 @@ onChange?: (isOpen: boolean) => void (optional)` // optional
 
 If provided along with `isOpen`, this will be called when FloatyBox wants to change state.
 
-## Todo
+## Development
 
-- Support for animations by adding an option to always render bubble
-- Option to auto close bubble when anchor moves off screen
-- Ease into new positions, rather than snapping directly
-- Allow `closeOnOutsideClick` and `closeOnEsc` to work when controlling state externally
-- Allow multiple floatyboxes to share a tooltip
+React-floatybox is written and maintained by [Damien Clarke](https://damienclarke.me/), with feedback from others at [92green](https://github.com/92green).
+All online library discussion happens over on [Github](https://github.com/92green/react-floatybox).
+
+I hope this library helps solve some React positioning problems for you. 🎉

--- a/packages/react-floatybox/README.md
+++ b/packages/react-floatybox/README.md
@@ -77,8 +77,20 @@ const Basic = (props) => {
 
 ## Props
 
+### children
+
+```flow
+children: React.Node
+```
+
+The React element that the bubble is tethered to, called the "anchor".
+It can handle click and hover events to control the open state of the bubble.
+
 ### bubble
-`({close, isOpen, tailProps}) => React.Node`
+
+```flow
+bubble: ({close, isOpen, tailProps}) => React.Node
+```
 
 A function for FloatyBox to call to render the floaty box.
 It's recommended you wrap this in a `useCallback` hook to improve rendering performance.
@@ -90,83 +102,147 @@ The function is passed an object with a few properties:
 | **isOpen**    | `boolean`                                     | A boolean indicating if the bubble is open.                                         |
 | **tailProps** | `{side: string, size: number, style: Object}` | An object that can be spread onto a tail component such as `react-floatybox/Point`. |
 
-
-### children
-`React.Node`
-
-The React element that the bubble is tethered to, called the "anchor".
-It can handle click and hover events to control the open state of the bubble.
-
 ### open
-`"click"|"hover"|"always" (optional)`
+
+```flow
+open?: "click"|"hover"|"always" // optional
+```
 
 If provided, this sets the kind of interaction that will open and close the bubble.
 
 ### side
-`"top"|"bottom"|"left"|"right", default = "top"`
+
+```flow
+side: "top"|"bottom"|"left"|"right" = "top"
+```
 
 Chooses the preferred side of the anchor that the bubble should appear on.
 
 ### align
-`string (optional), default = "center"`
 
-Sets the bubble's preferred perpendicular alignment.
+```flow
+align: string = "center"
+```
+
+Sets the bubble's preferred alignment in relation to its tail.
+
+- When `side` is `"top"` or `"bottom"`, valid values are `"center"`, `"left"` or `"right"`.
+- When `side` is `"left"` or `"right"`, valid values are `"center"`, `"up"` or `"down"`.
+
+### alignInner
+
+```flow
+alignInner: string = "center"
+```
+
+Sets the tail's preferred alignment in relation to the anchor.
+
+When building things with small anchors and large bubbles, such as tooltips, this prop is usually best on its default "center" setting. But if your anchor is larger than your bubble then this alignment becomes more useful.
+
 - When `side` is `"top"` or `"bottom"`, valid values are `"center"`, `"left"` or `"right"`.
 - When `side` is `"left"` or `"right"`, valid values are `"center"`, `"up"` or `"down"`.
 
 ### flip
-`boolean, default = false`
+
+```flow
+flip: boolean = false
+```
 
 Set to true to allow FloatyBox to flip the bubble to the opposite side of the anchor if there is not enough space to fit it on the preferred side.
 
+### slide
+
+```flow
+slide: boolean = false
+```
+
+Set to true to allow FloatyBox to slide the bubble across the side of the anchor if there is not enough space to fit it at the preferred alignment.
+
+### trap
+
+```flow
+trap: boolean = false
+```
+
+Trap will prevent the bubble from ever leaving the screen.
+
 ### gap
-`number (optional), default = 10`
+
+```flow
+gap: number = 10
+```
 
 The gap between the bubble and the anchor, in pixels.
 
 ### edge
-`number (optional), default = 10`
+
+```flow
+edge: number = 10
+```
 
 How close the bubble is allowed to be posiitioned near a screen edge, in pixels.
 
 ### zIndex
-`number (optional), default = 100`
+
+```flow
+zIndex: number = 100
+```
 
 The `zIndex` of the bubble element.
 
 ### closeOnOutsideClick
-`boolean (optional), default = true`
+
+```flow
+closeOnOutsideClick: boolean = true
+```
 
 A [react-useportal](https://github.com/alex-cory/react-useportal) option that lets the bubble close when you click outside of it.
 
 ### closeOnEsc
-`boolean (optional), default = true`
+
+```flow
+closeOnEsc: boolean = true
+```
 
 A [react-useportal](https://github.com/alex-cory/react-useportal) option that lets the bubble close when you press the escape key.
 
 ### tailSize
-`number (optional)`
+
+```flow
+tailSize?: number // optional
+```
 
 If a tail is used on your bubble, `tailSize` must be set so FloatyBox can adjust its positioning.
 
 ### wrap
-`React.Component (optional), default = "span"`
+
+```flow
+wrap: React.Component = "span"
+```
 
 The component that the FloatyBox anchor gets wrapped in.
 
 ### forceUpdate
 
-`Array<any> (optional) default = []`
+```flow
+forceUpdate: Array<any> = []
+```
 
 The forceUpdate prop allows you to force the bubble position to update. Pass it an array of values, and when any of these values change then the bubble position will be recalculated.
 
 ### isOpen
-`boolean (optional)`
+
+```flow
+isOpen?: boolean // optional
+```
 
 If provided, FloatyBox won't keep its own state and will just be open when this boolean is `true`.
 
 ### onChange
-`(isOpen: boolean) => void (optional)`
+
+```flow
+onChange?: (isOpen: boolean) => void (optional)` // optional
+```
 
 If provided along with `isOpen`, this will be called when FloatyBox wants to change state.
 
@@ -177,4 +253,3 @@ If provided along with `isOpen`, this will be called when FloatyBox wants to cha
 - Ease into new positions, rather than snapping directly
 - Allow `closeOnOutsideClick` and `closeOnEsc` to work when controlling state externally
 - Allow multiple floatyboxes to share a tooltip
-- Work out if its possible to not createReact portals until required when using react-useportal

--- a/packages/react-floatybox/src/FloatyBox.jsx
+++ b/packages/react-floatybox/src/FloatyBox.jsx
@@ -365,7 +365,7 @@ export const positionOnAxis = (
         let pos = lerp(startPos, endPos, axis[side]);
 
         // if using flip, flip side if there isnt enough room on preferred side
-        if(flip && pos < edge || pos + bubbleSize > windowSize - edge) {
+        if(flip && (pos < edge || pos + bubbleSize > windowSize - edge)) {
             pos = lerp(endPos, startPos, axis[side]);
         }
 

--- a/packages/react-floatybox/src/FloatyBox.jsx
+++ b/packages/react-floatybox/src/FloatyBox.jsx
@@ -401,7 +401,7 @@ export const positionOnAxis = (
 
     // if using slide, slide bubble along if too close to screen edges
     let tailHide = false;
-    if(slide) {
+    if(slide || trap) {
         pos = clamp(pos, edge, windowSize - bubbleSize - edge);
 
         // find out if the tail has detached


### PR DESCRIPTION
- **BREAKING CHANGE** default behaviour now doesn't trap the bubble on screen
- **BREAKING CHANGE** default props now don't provide an `edge` value of 10.
- **BREAKING CHANGE** default props now don't provide a `gap` value of 10.
- Added `alignInner` to align the tail against the anchor
- Added `trap` to toggle whether the bubble is always trapped on screen or if its allowed to slide off
- Added `flip` and `slide` as options to toggle those screen-edge avoiding behaviours

I can only think of one more tweak to the alignment algorithm (slide should probably also attempt to slide the value of `alignInner` too), and one more alignment option (`inside` to align on the inside of the anchor rather than the outside) but those will be thought about later.