### PR TITLE
Release/shady sole

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,12 @@ If a tail is used on your bubble, `tailSize` must be set so FloatyBox can adjust
 
 The component that the FloatyBox anchor gets wrapped in.
 
+### forceUpdate
+
+`Array<any> (optional) default = []`
+
+The forceUpdate prop allows you to force the bubble position to update. Pass it an array of values, and when any of these values change then the bubble position will be recalculated.
+
 ### isOpen
 `boolean (optional)`
 
@@ -169,8 +175,6 @@ If provided along with `isOpen`, this will be called when FloatyBox wants to cha
 - Support for animations by adding an option to always render bubble
 - Option to auto close bubble when anchor moves off screen
 - Ease into new positions, rather than snapping directly
-- Add option to continually update, for when a FloatyBox is inside something that constantly moves
-- Add option to manually update, such as on prop change
 - Allow `closeOnOutsideClick` and `closeOnEsc` to work when controlling state externally
 - Allow multiple floatyboxes to share a tooltip
 - Work out if its possible to not createReact portals until required when using react-useportal

--- a/README.md
+++ b/README.md
@@ -114,6 +114,11 @@ Sets the bubble's preferred perpendicular alignment.
 - When `side` is `"top"` or `"bottom"`, valid values are `"center"`, `"left"` or `"right"`.
 - When `side` is `"left"` or `"right"`, valid values are `"center"`, `"up"` or `"down"`.
 
+### flip
+`boolean, default = false`
+
+Set to true to allow FloatyBox to flip the bubble to the opposite side of the anchor if there is not enough space to fit it on the preferred side.
+
 ### gap
 `number (optional), default = 10`
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ const Basic = (props) => {
         return <div>I am a thing</div>;
     }, []);
 
-    return <FloatyBox open="click" align="lt" bubble={tooltip}>click me!</FloatyBox>;
+    return <FloatyBox open="click" side="top" align="left" bubble={tooltip}>click me!</FloatyBox>;
 };
 ```
 
@@ -114,23 +114,17 @@ It can handle click and hover events to control the open state of the bubble.
 
 If provided, this sets the kind of interaction that will open and close the bubble.
 
+#### side
+`"top"|"bottom"|"left"|"right", default = "top"`
+
+Chooses the preferred side of the anchor that the bubble should appear on.
+
 #### align
-`string (optional), default = "tc"`
+`string (optional), default = "center"`
 
-Sets the preferred positioning of the bubble relative to the anchor. Options are:
-
-- `tl` - top left
-- `tc` - top centre
-- `tr` - top right
-- `bl` - bottom left
-- `bc` - bottom centre
-- `br` - bottom right
-- `lt` - left top
-- `lc` - left centre
-- `lb` - left bottom
-- `rt` - right top
-- `rc` - right centre
-- `rb` - right bottom
+Sets the bubble's preferred perpendicular alignment.
+- When `side` is `"top"` or `"bottom"`, valid values are `"center"`, `"left"` or `"right"`.
+- When `side` is `"left"` or `"right"`, valid values are `"center"`, `"up"` or `"down"`.
 
 ### gap
 `number (optional), default = 10`
@@ -183,5 +177,7 @@ If provided along with `isOpen`, this will be called when FloatyBox wants to cha
 - Option to auto close bubble when anchor moves off screen
 - Ease into new positions, rather than snapping directly
 - Add option to continually update, for when a FloatyBox is inside something that constantly moves
+- Add option to manually update, such as on prop change
 - Allow `closeOnOutsideClick` and `closeOnEsc` to work when controlling state externally
+- Allow multiple floatyboxes to share a tooltip
 - Work out if its possible to not createReact portals until required when using react-useportal

--- a/README.md
+++ b/README.md
@@ -4,11 +4,17 @@ A React component for positioning floating components such as tooltips, dropdown
 
 * **[See some examples - coming soon](#)**
 
+- [Features](#features)
+- [Installation](#installation)
+- [Usage](#usage)
+- [Props](#props)
+- [Development](#development)
+
 ## Features
 - Handles all your bubble positioning
 - Avoids screen edges
 - Bubble size and position can be determined automatically, specified widths and heights not required
-- Built in support for positining of tails (those little pointy things at the bottom of tooltips)
+- Built in support for positioning of tails (those little pointy things at the bottom of tooltips)
 - Built in behaviour to open and close via hover or click, and to close via click-outside or ESC key
 - Can use its own state or can be controlled
 - Uses React portals via the [react-useportal](https://github.com/alex-cory/react-useportal) hook
@@ -77,8 +83,20 @@ const Basic = (props) => {
 
 ## Props
 
+### children
+
+```flow
+children: React.Node
+```
+
+The React element that the bubble is tethered to, called the "anchor".
+It can handle click and hover events to control the open state of the bubble.
+
 ### bubble
-`({close, isOpen, tailProps}) => React.Node`
+
+```flow
+bubble: ({close, isOpen, tailProps}) => React.Node
+```
 
 A function for FloatyBox to call to render the floaty box.
 It's recommended you wrap this in a `useCallback` hook to improve rendering performance.
@@ -90,91 +108,153 @@ The function is passed an object with a few properties:
 | **isOpen**    | `boolean`                                     | A boolean indicating if the bubble is open.                                         |
 | **tailProps** | `{side: string, size: number, style: Object}` | An object that can be spread onto a tail component such as `react-floatybox/Point`. |
 
-
-### children
-`React.Node`
-
-The React element that the bubble is tethered to, called the "anchor".
-It can handle click and hover events to control the open state of the bubble.
-
 ### open
-`"click"|"hover"|"always" (optional)`
+
+```flow
+open?: "click"|"hover"|"always" // optional
+```
 
 If provided, this sets the kind of interaction that will open and close the bubble.
 
 ### side
-`"top"|"bottom"|"left"|"right", default = "top"`
+
+```flow
+side: "top"|"bottom"|"left"|"right" = "top"
+```
 
 Chooses the preferred side of the anchor that the bubble should appear on.
 
 ### align
-`string (optional), default = "center"`
 
-Sets the bubble's preferred perpendicular alignment.
+```flow
+align: string = "center"
+```
+
+Sets the bubble's preferred alignment in relation to its tail.
+
+- When `side` is `"top"` or `"bottom"`, valid values are `"center"`, `"left"` or `"right"`.
+- When `side` is `"left"` or `"right"`, valid values are `"center"`, `"up"` or `"down"`.
+
+### alignInner
+
+```flow
+alignInner: string = "center"
+```
+
+Sets the tail's preferred alignment in relation to the anchor.
+
+When building things with small anchors and large bubbles, such as tooltips, this prop is usually best on its default "center" setting. But if your anchor is larger than your bubble then this alignment becomes more useful.
+
 - When `side` is `"top"` or `"bottom"`, valid values are `"center"`, `"left"` or `"right"`.
 - When `side` is `"left"` or `"right"`, valid values are `"center"`, `"up"` or `"down"`.
 
 ### flip
-`boolean, default = false`
+
+```flow
+flip: boolean = false
+```
 
 Set to true to allow FloatyBox to flip the bubble to the opposite side of the anchor if there is not enough space to fit it on the preferred side.
 
+### slide
+
+```flow
+slide: boolean = false
+```
+
+Set to true to allow FloatyBox to slide the bubble across the side of the anchor if there is not enough space to fit it at the preferred alignment.
+
+### trap
+
+```flow
+trap: boolean = false
+```
+
+Trap will prevent the bubble from ever leaving the screen.
+
 ### gap
-`number (optional), default = 10`
+
+```flow
+gap: number = 10
+```
 
 The gap between the bubble and the anchor, in pixels.
 
 ### edge
-`number (optional), default = 10`
+
+```flow
+edge: number = 10
+```
 
 How close the bubble is allowed to be posiitioned near a screen edge, in pixels.
 
 ### zIndex
-`number (optional), default = 100`
+
+```flow
+zIndex: number = 100
+```
 
 The `zIndex` of the bubble element.
 
 ### closeOnOutsideClick
-`boolean (optional), default = true`
+
+```flow
+closeOnOutsideClick: boolean = true
+```
 
 A [react-useportal](https://github.com/alex-cory/react-useportal) option that lets the bubble close when you click outside of it.
 
 ### closeOnEsc
-`boolean (optional), default = true`
+
+```flow
+closeOnEsc: boolean = true
+```
 
 A [react-useportal](https://github.com/alex-cory/react-useportal) option that lets the bubble close when you press the escape key.
 
 ### tailSize
-`number (optional)`
+
+```flow
+tailSize?: number // optional
+```
 
 If a tail is used on your bubble, `tailSize` must be set so FloatyBox can adjust its positioning.
 
 ### wrap
-`React.Component (optional), default = "span"`
+
+```flow
+wrap: React.Component = "span"
+```
 
 The component that the FloatyBox anchor gets wrapped in.
 
 ### forceUpdate
 
-`Array<any> (optional) default = []`
+```flow
+forceUpdate: Array<any> = []
+```
 
 The forceUpdate prop allows you to force the bubble position to update. Pass it an array of values, and when any of these values change then the bubble position will be recalculated.
 
 ### isOpen
-`boolean (optional)`
+
+```flow
+isOpen?: boolean // optional
+```
 
 If provided, FloatyBox won't keep its own state and will just be open when this boolean is `true`.
 
 ### onChange
-`(isOpen: boolean) => void (optional)`
+
+```flow
+onChange?: (isOpen: boolean) => void (optional)` // optional
+```
 
 If provided along with `isOpen`, this will be called when FloatyBox wants to change state.
 
-## Todo
+## Development
 
-- Support for animations by adding an option to always render bubble
-- Option to auto close bubble when anchor moves off screen
-- Ease into new positions, rather than snapping directly
-- Allow `closeOnOutsideClick` and `closeOnEsc` to work when controlling state externally
-- Allow multiple floatyboxes to share a tooltip
-- Work out if its possible to not createReact portals until required when using react-useportal
+React-floatybox is written and maintained by [Damien Clarke](https://damienclarke.me/), with feedback from others at [92green](https://github.com/92green).
+All online library discussion happens over on [Github](https://github.com/92green/react-floatybox).
+
+I hope this library helps solve some React positioning problems for you. 🎉

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ The React element that the bubble is tethered to, called the "anchor".
 It can handle click and hover events to control the open state of the bubble.
 
 ### open
-`"click"|"hover" (optional)`
+`"click"|"hover"|"always" (optional)`
 
 If provided, this sets the kind of interaction that will open and close the bubble.
 

--- a/packages/react-floatybox-docs/gatsby-config.js
+++ b/packages/react-floatybox-docs/gatsby-config.js
@@ -1,17 +1,11 @@
 // @flow
 const {gatsbyConfig} = require('dcme-gatsby/src/gatsby/gatsby-config');
 
-gatsbyConfig.plugins.unshift({
-    resolve: `gatsby-plugin-compile-es6-packages`,
-    options: {
-        modules: [`dcme-gatsby`, `dcme-style`],
-        test: /\.jsx?$/
-    }
-});
-
 module.exports = {
     siteMetadata: {
         title: 'React Floatybox Demo'
     },
-    ...gatsbyConfig
+    ...gatsbyConfig({
+        compileModules: [`dcme-gatsby`, `dcme-style`]
+    })
 };

--- a/packages/react-floatybox-docs/package.json
+++ b/packages/react-floatybox-docs/package.json
@@ -12,11 +12,12 @@
     "deploy": "yarn gatsby build --prefix-paths && gh-pages -d public"
   },
   "dependencies": {
-    "dcme-gatsby": "^1.0.5",
-    "dcme-style": "^1.0.5",
+    "dcme-gatsby": "^1.0.8",
+    "dcme-style": "^1.1.7",
     "gatsby": "^2.16.5",
     "gatsby-plugin-compile-es6-packages": "^2.1.0",
     "gh-pages": "^1.1.0",
+    "react-dataparcels": "^1.0.2",
     "react-floatybox": "^0.2.0",
     "react-use-dimensions": "1.2.1",
     "react-use-real-dimensions": "^0.1.0"

--- a/packages/react-floatybox-docs/src/component/DragMe.js
+++ b/packages/react-floatybox-docs/src/component/DragMe.js
@@ -26,7 +26,7 @@ import ParcelBoundary from 'react-dataparcels/ParcelBoundary';
 
 const INITIAL_PROPS = {
     props: {
-        open: 'click',
+        open: 'always',
         tailSize: 20,
         side: 'top',
         align: 'center',
@@ -85,13 +85,13 @@ export const DragMe = styled((props: any) => {
 
     return <div className={props.className}>
         <Flex display={['block', 'flex']}>
-            <Box width="33%" mr={[null, 3]} mb={[3, null]}>
+            <Box width="33%" mr={[null, 3]} mb={[3, null]} p={[4,5]}>
                 <DragBox big={demoParcel.value.demo.big} floatyBoxProps={floatyBoxProps} />
             </Box>
             <Box width="33%" mr={[null, 3]} mb={[3, null]}>
                 <H4>Props</H4>
                 <ParcelBoundary parcel={demoParcel.getIn(['props','open'])}>
-                    {(parcel) => <InputRow label="open"><Select {...parcel.spreadDOM()} options={['click','hover']} /></InputRow>}
+                    {(parcel) => <InputRow label="open"><Select {...parcel.spreadDOM()} options={['always','click','hover']} /></InputRow>}
                 </ParcelBoundary>
                 <ParcelBoundary parcel={demoParcel.getIn(['props','side'])}>
                     {(parcel) => <InputRow label="side"><Select {...parcel.spreadDOM()} options={['top','bottom','left','right']} /></InputRow>}

--- a/packages/react-floatybox-docs/src/component/DragMe.js
+++ b/packages/react-floatybox-docs/src/component/DragMe.js
@@ -32,6 +32,7 @@ const INITIAL_PROPS = {
         align: 'center',
         gap: 10,
         edge: 10,
+        flip: true,
         wrap: 'div'
     },
     demo: {
@@ -98,6 +99,9 @@ export const DragMe = styled((props: any) => {
                 </ParcelBoundary>
                 <ParcelBoundary parcel={demoParcel.getIn(['props','align'])} forceUpdate={[alignOptions]}>
                     {(parcel) => <InputRow label="align"><Select {...parcel.spreadDOM()} options={alignOptions} /></InputRow>}
+                </ParcelBoundary>
+                <ParcelBoundary parcel={demoParcel.getIn(['props','flip'])}>
+                    {(parcel) => <InputRow label="flip"><Checkbox {...parcel.spreadDOMCheckbox()} /></InputRow>}
                 </ParcelBoundary>
                 <ParcelBoundary parcel={demoParcel.getIn(['props','gap'])}>
                     {(parcel) => <InputRow label="gap"><Input type="number" width="100%" {...parcel.spreadDOM()} /></InputRow>}
@@ -171,7 +175,8 @@ const DragBox = (props: any): Node => {
         ? {
             position: 'absolute',
             top: position.top,
-            left: position.left
+            left: position.left,
+            zIndex: 50
         }
         : {};
 

--- a/packages/react-floatybox-docs/src/component/DragMe.js
+++ b/packages/react-floatybox-docs/src/component/DragMe.js
@@ -26,7 +26,7 @@ import ParcelBoundary from 'react-dataparcels/ParcelBoundary';
 
 const INITIAL_PROPS = {
     props: {
-        open: 'always',
+        open: 'click',
         tailSize: 20,
         side: 'top',
         align: 'center',
@@ -171,17 +171,26 @@ const DragBox = (props: any): Node => {
         document.addEventListener('mousemove', mouseMove);
     }, [position]);
 
-    let style = position
-        ? {
+    let style = {};
+    let forceUpdate = [props.big, null, null];
+
+    if(position) {
+        style = {
             position: 'absolute',
             top: position.top,
             left: position.left,
             zIndex: 50
-        }
-        : {};
+        };
+
+        forceUpdate = [
+            props.big,
+            position.top,
+            position.left
+        ];
+    }
 
     return <div ref={ref} style={style} onMouseDown={onMouseDown}>
-        <FloatyBox {...props.floatyBoxProps}>
+        <FloatyBox {...props.floatyBoxProps} forceUpdate={forceUpdate}>
             <InnerBox big={props.big}></InnerBox>
         </FloatyBox>
     </div>;

--- a/packages/react-floatybox-docs/src/component/DragMe.js
+++ b/packages/react-floatybox-docs/src/component/DragMe.js
@@ -26,17 +26,21 @@ import ParcelBoundary from 'react-dataparcels/ParcelBoundary';
 
 const INITIAL_PROPS = {
     props: {
-        open: 'click',
+        open: 'always',
         tailSize: 20,
         side: 'top',
         align: 'center',
+        alignInner: 'center',
         gap: 10,
         edge: 10,
         flip: true,
+        slide: true,
+        trap: false,
         wrap: 'div'
     },
     demo: {
-        big: false
+        big: false,
+        tail: true
     }
 };
 
@@ -67,17 +71,20 @@ export const DragMe = styled((props: any) => {
         beforeChange: (value) => {
             if(!getAlignOptions(value.props.side).includes(value.props.align)) {
                 value.props.align = 'center';
+                value.props.alignInner = 'center';
             }
             return value;
         }
     });
 
     let bubble = useCallback(({tailProps}) => {
-        return <Tooltip>I am a tooltip <Point {...tailProps} color="#000" /></Tooltip>;
-    }, []);
+        return <Tooltip>I am a tooltip {demoParcel.value.demo.tail && <Point {...tailProps} color="#000" />}</Tooltip>;
+    }, [demoParcel.value.demo.tail]);
 
     let floatyBoxProps = {
         ...demoParcel.value.props,
+        gap: Number(demoParcel.value.props.gap),
+        edge: demoParcel.value.props.edge === '' ? undefined : Number(demoParcel.value.props.edge),
         tailSize: Number(demoParcel.value.props.tailSize),
         bubble
     };
@@ -100,8 +107,17 @@ export const DragMe = styled((props: any) => {
                 <ParcelBoundary parcel={demoParcel.getIn(['props','align'])} forceUpdate={[alignOptions]}>
                     {(parcel) => <InputRow label="align"><Select {...parcel.spreadDOM()} options={alignOptions} /></InputRow>}
                 </ParcelBoundary>
+                <ParcelBoundary parcel={demoParcel.getIn(['props','alignInner'])} forceUpdate={[alignOptions]}>
+                    {(parcel) => <InputRow label="alignInner"><Select {...parcel.spreadDOM()} options={alignOptions} /></InputRow>}
+                </ParcelBoundary>
                 <ParcelBoundary parcel={demoParcel.getIn(['props','flip'])}>
                     {(parcel) => <InputRow label="flip"><Checkbox {...parcel.spreadDOMCheckbox()} /></InputRow>}
+                </ParcelBoundary>
+                <ParcelBoundary parcel={demoParcel.getIn(['props','slide'])}>
+                    {(parcel) => <InputRow label="slide"><Checkbox {...parcel.spreadDOMCheckbox()} /></InputRow>}
+                </ParcelBoundary>
+                <ParcelBoundary parcel={demoParcel.getIn(['props','trap'])}>
+                    {(parcel) => <InputRow label="trap"><Checkbox {...parcel.spreadDOMCheckbox()} /></InputRow>}
                 </ParcelBoundary>
                 <ParcelBoundary parcel={demoParcel.getIn(['props','gap'])}>
                     {(parcel) => <InputRow label="gap"><Input type="number" width="100%" {...parcel.spreadDOM()} /></InputRow>}
@@ -118,13 +134,15 @@ export const DragMe = styled((props: any) => {
                 <ParcelBoundary parcel={demoParcel.getIn(['demo','big'])}>
                     {(parcel) => <InputRow label="big"><Checkbox {...parcel.spreadDOMCheckbox()} /></InputRow>}
                 </ParcelBoundary>
+                <ParcelBoundary parcel={demoParcel.getIn(['demo','tail'])}>
+                    {(parcel) => <InputRow label="tail"><Checkbox {...parcel.spreadDOMCheckbox()} /></InputRow>}
+                </ParcelBoundary>
             </Box>
         </Flex>
     </div>;
 })`
     border: 1px dashed ${props => props.theme.colors.line};
     width: 100%;
-    height: 20rem;
     padding: 1rem;
 `;
 

--- a/packages/react-floatybox-docs/src/component/DragMe.js
+++ b/packages/react-floatybox-docs/src/component/DragMe.js
@@ -1,0 +1,201 @@
+// @flow
+import type {Node} from 'react';
+
+import React from 'react';
+// $FlowFixMe
+import {useCallback} from 'react';
+// $FlowFixMe
+import {useState} from 'react';
+// $FlowFixMe
+import {useRef} from 'react';
+
+import FloatyBox from 'react-floatybox';
+import Point from 'react-floatybox/Point';
+
+import styled from 'styled-components';
+import {Flex} from 'dcme-style/layout';
+import {Box} from 'dcme-style/layout';
+import {H4} from 'dcme-style';
+import {Checkbox} from 'dcme-style/affordance';
+import {Input} from 'dcme-style/affordance';
+import {Select} from 'dcme-style/affordance';
+import {Text} from 'dcme-style/affordance';
+
+import useParcelState from 'react-dataparcels/useParcelState';
+import ParcelBoundary from 'react-dataparcels/ParcelBoundary';
+
+const INITIAL_PROPS = {
+    props: {
+        open: 'click',
+        tailSize: 20,
+        side: 'top',
+        align: 'center',
+        gap: 10,
+        edge: 10,
+        wrap: 'div'
+    },
+    demo: {
+        big: false
+    }
+};
+
+const getAlignOptions = (side) => {
+    let vertical = side === 'top' || side === 'bottom';
+    return vertical ? ['center','left','right'] : ['center','up','down'];
+};
+
+const Tooltip = styled.div`
+    background-color: #000;
+    color: #FFF;
+    padding: 1rem;
+`;
+
+const InputRow = ({children, label}: any): Node => {
+    return <Flex as="label" my={2} alignItems="center">
+        <Box mr="auto">
+            <Text textStyle="label">{label}</Text>
+        </Box>
+        <Box width="6rem">{children}</Box>
+    </Flex>;
+};
+
+export const DragMe = styled((props: any) => {
+
+    let [demoParcel] = useParcelState({
+        value: () => INITIAL_PROPS,
+        beforeChange: (value) => {
+            if(!getAlignOptions(value.props.side).includes(value.props.align)) {
+                value.props.align = 'center';
+            }
+            return value;
+        }
+    });
+
+    let bubble = useCallback(({tailProps}) => {
+        return <Tooltip>I am a tooltip <Point {...tailProps} color="#000" /></Tooltip>;
+    }, []);
+
+    let floatyBoxProps = {
+        ...demoParcel.value.props,
+        tailSize: Number(demoParcel.value.props.tailSize),
+        bubble
+    };
+
+    let alignOptions = getAlignOptions(demoParcel.getIn(['props','side']).value);
+
+    return <div className={props.className}>
+        <Flex display={['block', 'flex']}>
+            <Box width="33%" mr={[null, 3]} mb={[3, null]}>
+                <DragBox big={demoParcel.value.demo.big} floatyBoxProps={floatyBoxProps} />
+            </Box>
+            <Box width="33%" mr={[null, 3]} mb={[3, null]}>
+                <H4>Props</H4>
+                <ParcelBoundary parcel={demoParcel.getIn(['props','open'])}>
+                    {(parcel) => <InputRow label="open"><Select {...parcel.spreadDOM()} options={['click','hover']} /></InputRow>}
+                </ParcelBoundary>
+                <ParcelBoundary parcel={demoParcel.getIn(['props','side'])}>
+                    {(parcel) => <InputRow label="side"><Select {...parcel.spreadDOM()} options={['top','bottom','left','right']} /></InputRow>}
+                </ParcelBoundary>
+                <ParcelBoundary parcel={demoParcel.getIn(['props','align'])} forceUpdate={[alignOptions]}>
+                    {(parcel) => <InputRow label="align"><Select {...parcel.spreadDOM()} options={alignOptions} /></InputRow>}
+                </ParcelBoundary>
+                <ParcelBoundary parcel={demoParcel.getIn(['props','gap'])}>
+                    {(parcel) => <InputRow label="gap"><Input type="number" width="100%" {...parcel.spreadDOM()} /></InputRow>}
+                </ParcelBoundary>
+                <ParcelBoundary parcel={demoParcel.getIn(['props','edge'])}>
+                    {(parcel) => <InputRow label="edge"><Input type="number" width="100%" {...parcel.spreadDOM()} /></InputRow>}
+                </ParcelBoundary>
+                <ParcelBoundary parcel={demoParcel.getIn(['props','tailSize'])}>
+                    {(parcel) => <InputRow label="tailSize"><Input type="number" width="100%" {...parcel.spreadDOM()} /></InputRow>}
+                </ParcelBoundary>
+            </Box>
+            <Box width="33%">
+                <H4>Demo options</H4>
+                <ParcelBoundary parcel={demoParcel.getIn(['demo','big'])}>
+                    {(parcel) => <InputRow label="big"><Checkbox {...parcel.spreadDOMCheckbox()} /></InputRow>}
+                </ParcelBoundary>
+            </Box>
+        </Flex>
+    </div>;
+})`
+    border: 1px dashed ${props => props.theme.colors.line};
+    width: 100%;
+    height: 20rem;
+    padding: 1rem;
+`;
+
+const DragBox = (props: any): Node => {
+
+    let [position, setPosition] = useState(null);
+    let dragStart = useRef();
+
+    let mouseMove = useCallback((e) => {
+        if(!dragStart.current) {
+            return;
+        }
+        let drag = dragStart.current;
+
+
+        setPosition({
+            top: drag.top + (e.clientY - drag.clientY),
+            left: drag.left + (e.clientX - drag.clientX)
+        });
+    }, []);
+
+    let ref = useCallback(node => {
+        if(!node) {
+            return;
+        }
+
+        setPosition({
+            top: node.offsetTop,
+            left: node.offsetLeft
+        });
+
+        document.addEventListener('mouseup', () => {
+            document.removeEventListener('mousemove', mouseMove);
+        });
+    }, []);
+
+    let onMouseDown = useCallback((e) => {
+        dragStart.current = {
+            clientX: e.clientX,
+            clientY: e.clientY,
+            left: position.left,
+            top: position.top
+        };
+        document.addEventListener('mousemove', mouseMove);
+    }, [position]);
+
+    let style = position
+        ? {
+            position: 'absolute',
+            top: position.top,
+            left: position.left
+        }
+        : {};
+
+    return <div ref={ref} style={style} onMouseDown={onMouseDown}>
+        <FloatyBox {...props.floatyBoxProps}>
+            <InnerBox big={props.big}></InnerBox>
+        </FloatyBox>
+    </div>;
+};
+
+const InnerBox = styled.div`
+    width: ${props => props.big ? '12rem' : '3rem'};
+    height: ${props => props.big ? '12rem' : '3rem'};
+    background: ${props => props.theme.colors.primary};
+    border-radius: 5px;
+    text-align: center;
+    cursor: move;
+    cursor: grab;
+    font-size: .8rem;
+    line-height: 1.2rem;
+    font-family: ${props => props.theme.fonts.monospace};
+    user-select: none;
+
+    &:active {
+        cursor: grabbing;
+    }
+`;

--- a/packages/react-floatybox-docs/src/pages/dimensions.js
+++ b/packages/react-floatybox-docs/src/pages/dimensions.js
@@ -1,7 +1,7 @@
 // @flow
 import React from 'react';
 import Page from 'component/Page';
-import {H2} from 'dcme-style';
+import {H1} from 'dcme-style';
 import {Box} from 'dcme-style/layout';
 import {Text} from 'dcme-style/affordance';
 import {Link} from 'dcme-style/affordance';
@@ -25,8 +25,8 @@ export default () => {
     return <Page>
         <Box p={[3,4]} maxWidth="800px" margin="0 auto">
             <Box mb={5}>
-                <Box mb={2}>
-                    <H2>react-use-real-dimensions 🕊️↔😌</H2>
+                <Box>
+                    <H1>react-use-real-dimensions 🕊️↔😌</H1>
                 </Box>
                 <Text textStyle="monospace">See also <Link to="/">react-floatybox</Link></Text>
             </Box>

--- a/packages/react-floatybox-docs/src/pages/index.js
+++ b/packages/react-floatybox-docs/src/pages/index.js
@@ -67,20 +67,22 @@ export default () => {
                 <Text>Control the state yourself <FloatyBox open="click" isOpen={isOpen} onChange={setOpen} bubble={tooltip}><Wow>like this!</Wow></FloatyBox></Text>
             </Box>
             <Box mb={4}>
-                <Text>Positioning is easy, just do </Text>
+                <Text>Positioning is easy, just use the <Wow>side</Wow> and <Wow>align</Wow> props.</Text>
+            </Box>
+            <Box mb={4}>
                 <Text>
-                    <FloatyBox open="click" bubble={tooltipWithTail} tailSize={20} align="tl"><Wow>tl</Wow></FloatyBox><Text> or </Text>
-                    <FloatyBox open="click" bubble={tooltipWithTail} tailSize={20} align="tc"><Wow>tc</Wow></FloatyBox><Text> or </Text>
-                    <FloatyBox open="click" bubble={tooltipWithTail} tailSize={20} align="tr"><Wow>tr</Wow></FloatyBox><Text> or </Text>
-                    <FloatyBox open="click" bubble={tooltipWithTail} tailSize={20} align="bl"><Wow>bl</Wow></FloatyBox><Text> or </Text>
-                    <FloatyBox open="click" bubble={tooltipWithTail} tailSize={20} align="bc"><Wow>bc</Wow></FloatyBox><Text> or </Text>
-                    <FloatyBox open="click" bubble={tooltipWithTail} tailSize={20} align="br"><Wow>br</Wow></FloatyBox><Text> or </Text>
-                    <FloatyBox open="click" bubble={tooltipWithTail} tailSize={20} align="lt"><Wow>lt</Wow></FloatyBox><Text> or </Text>
-                    <FloatyBox open="click" bubble={tooltipWithTail} tailSize={20} align="lc"><Wow>lc</Wow></FloatyBox><Text> or </Text>
-                    <FloatyBox open="click" bubble={tooltipWithTail} tailSize={20} align="lb"><Wow>lb</Wow></FloatyBox><Text> or </Text>
-                    <FloatyBox open="click" bubble={tooltipWithTail} tailSize={20} align="rt"><Wow>rt</Wow></FloatyBox><Text> or </Text>
-                    <FloatyBox open="click" bubble={tooltipWithTail} tailSize={20} align="rc"><Wow>rc</Wow></FloatyBox><Text> or </Text>
-                    <FloatyBox open="click" bubble={tooltipWithTail} tailSize={20} align="rb"><Wow>rb</Wow></FloatyBox><Text> or whatever.</Text>
+                    <FloatyBox open="click" bubble={tooltipWithTail} tailSize={20} side="top"><Wow>top</Wow></FloatyBox><Text> or </Text>
+                    <FloatyBox open="click" bubble={tooltipWithTail} tailSize={20} side="top" align="left"><Wow>top / left</Wow></FloatyBox><Text> or </Text>
+                    <FloatyBox open="click" bubble={tooltipWithTail} tailSize={20} side="top" align="right"><Wow>top / right</Wow></FloatyBox><Text> or </Text>
+                    <FloatyBox open="click" bubble={tooltipWithTail} tailSize={20} side="bottom"><Wow>bottom</Wow></FloatyBox><Text> or </Text>
+                    <FloatyBox open="click" bubble={tooltipWithTail} tailSize={20} side="bottom" align="left"><Wow>bottom / left</Wow></FloatyBox><Text> or </Text>
+                    <FloatyBox open="click" bubble={tooltipWithTail} tailSize={20} side="bottom" align="right"><Wow>bottom / right</Wow></FloatyBox><Text> or </Text>
+                    <FloatyBox open="click" bubble={tooltipWithTail} tailSize={20} side="left"><Wow>left</Wow></FloatyBox><Text> or </Text>
+                    <FloatyBox open="click" bubble={tooltipWithTail} tailSize={20} side="left" align="up"><Wow>left / up</Wow></FloatyBox><Text> or </Text>
+                    <FloatyBox open="click" bubble={tooltipWithTail} tailSize={20} side="left" align="down"><Wow>left / down</Wow></FloatyBox><Text> or </Text>
+                    <FloatyBox open="click" bubble={tooltipWithTail} tailSize={20} side="right"><Wow>right</Wow></FloatyBox><Text> or </Text>
+                    <FloatyBox open="click" bubble={tooltipWithTail} tailSize={20} side="right" align="up"><Wow>right / up</Wow></FloatyBox><Text> or </Text>
+                    <FloatyBox open="click" bubble={tooltipWithTail} tailSize={20} side="right" align="down"><Wow>right / down</Wow></FloatyBox><Text> or whatever.</Text>
                 </Text>
             </Box>
             <Box mb={4}>

--- a/packages/react-floatybox-docs/src/pages/index.js
+++ b/packages/react-floatybox-docs/src/pages/index.js
@@ -5,16 +5,18 @@ import {useState} from 'react';
 // $FlowFixMe
 import {useCallback} from 'react';
 import Page from 'component/Page';
-import {H2} from 'dcme-style';
+import {H1} from 'dcme-style';
 import {Box} from 'dcme-style/layout';
 import {Text} from 'dcme-style/affordance';
 import {Link} from 'dcme-style/affordance';
+import {ContentNav} from 'dcme-style';
 import styled from 'styled-components';
 
 import FloatyBox from 'react-floatybox';
 import Point from 'react-floatybox/Point';
 
 import ColorPicker from '../component/ColorPicker';
+import IndexMdx from './indexMdx.mdx';
 
 const Tooltip = styled.div`
     background-color: #000;
@@ -28,77 +30,33 @@ const Wow = styled.span`
 `;
 
 export default () => {
-    // state for "Control the state yourself" example
-    let [isOpen, setOpen] = useState(false);
+    // // state for "Control the state yourself" example
+    // let [isOpen, setOpen] = useState(false);
 
-    // state for color picker example
-    let [color, setColor] = useState('#F00');
+    // // state for color picker example
+    // let [color, setColor] = useState('#F00');
 
-    let tooltip = useCallback(() => {
-        return <Tooltip>Hello I'm a tooltip.</Tooltip>;
-    }, []);
+    // let tooltip = useCallback(() => {
+    //     return <Tooltip>Hello I'm a tooltip.</Tooltip>;
+    // }, []);
 
-    let tooltipWithTail = useCallback(({tailProps}) => {
-        return <Tooltip>Hello I'm a tooltip. <Point {...tailProps} color="#000" /></Tooltip>;
-    }, []);
+    // let tooltipWithTail = useCallback(({tailProps}) => {
+    //     return <Tooltip>Hello I'm a tooltip. <Point {...tailProps} color="#000" /></Tooltip>;
+    // }, []);
 
-    let closableTooltip = useCallback(({close}) => {
-        return <Tooltip>Tooltip <Wow onClick={close}>[x]</Wow>.</Tooltip>;
-    }, []);
+    // let closableTooltip = useCallback(({close}) => {
+    //     return <Tooltip>Tooltip <Wow onClick={close}>[x]</Wow>.</Tooltip>;
+    // }, []);
 
     return <Page>
         <Box pt={[3,4]} px={[3,4]} pb="100rem" maxWidth="800px" margin="0 auto">
             <Box mb={4}>
-                <Box mb={2}>
-                    <H2>react-floatybox 🎈🎁🎉</H2>
+                <Box>
+                    <H1>react-floatybox 🎈🎁🎉</H1>
                 </Box>
                 <Text textStyle="monospace">See also <Link to="/dimensions">react-use-real-dimensions</Link></Text>
             </Box>
-            <Box mb={4}>
-                <Text>A nice normal day, but then, <FloatyBox open="click" bubble={tooltip}><Wow>click me!</Wow></FloatyBox> or <FloatyBox open="hover" bubble={tooltip}><Wow>hover over me!</Wow></FloatyBox></Text>
-            </Box>
-            <Box mb={4}>
-                <Text>Do you like tails? Why not <FloatyBox open="click" bubble={tooltipWithTail} tailSize={20}><Wow>add one of ours!</Wow></FloatyBox></Text>
-            </Box>
-            <Box mb={4}>
-                <Text>Pass <Link href="https://github.com/alex-cory/react-useportal">react-useportal</Link> options as props (such as closeOnEsc = false) <FloatyBox open="click" bubble={tooltip} closeOnEsc={false}><Wow>like this!</Wow></FloatyBox></Text>
-            </Box>
-            <Box mb={4}>
-                <Text>Control the state yourself <FloatyBox open="click" isOpen={isOpen} onChange={setOpen} bubble={tooltip}><Wow>like this!</Wow></FloatyBox></Text>
-            </Box>
-            <Box mb={4}>
-                <Text>Positioning is easy, just use the <Wow>side</Wow> and <Wow>align</Wow> props.</Text>
-            </Box>
-            <Box mb={4}>
-                <Text>
-                    <FloatyBox open="click" bubble={tooltipWithTail} tailSize={20} side="top"><Wow>top</Wow></FloatyBox><Text> or </Text>
-                    <FloatyBox open="click" bubble={tooltipWithTail} tailSize={20} side="top" align="left"><Wow>top / left</Wow></FloatyBox><Text> or </Text>
-                    <FloatyBox open="click" bubble={tooltipWithTail} tailSize={20} side="top" align="right"><Wow>top / right</Wow></FloatyBox><Text> or </Text>
-                    <FloatyBox open="click" bubble={tooltipWithTail} tailSize={20} side="bottom"><Wow>bottom</Wow></FloatyBox><Text> or </Text>
-                    <FloatyBox open="click" bubble={tooltipWithTail} tailSize={20} side="bottom" align="left"><Wow>bottom / left</Wow></FloatyBox><Text> or </Text>
-                    <FloatyBox open="click" bubble={tooltipWithTail} tailSize={20} side="bottom" align="right"><Wow>bottom / right</Wow></FloatyBox><Text> or </Text>
-                    <FloatyBox open="click" bubble={tooltipWithTail} tailSize={20} side="left"><Wow>left</Wow></FloatyBox><Text> or </Text>
-                    <FloatyBox open="click" bubble={tooltipWithTail} tailSize={20} side="left" align="up"><Wow>left / up</Wow></FloatyBox><Text> or </Text>
-                    <FloatyBox open="click" bubble={tooltipWithTail} tailSize={20} side="left" align="down"><Wow>left / down</Wow></FloatyBox><Text> or </Text>
-                    <FloatyBox open="click" bubble={tooltipWithTail} tailSize={20} side="right"><Wow>right</Wow></FloatyBox><Text> or </Text>
-                    <FloatyBox open="click" bubble={tooltipWithTail} tailSize={20} side="right" align="up"><Wow>right / up</Wow></FloatyBox><Text> or </Text>
-                    <FloatyBox open="click" bubble={tooltipWithTail} tailSize={20} side="right" align="down"><Wow>right / down</Wow></FloatyBox><Text> or whatever.</Text>
-                </Text>
-            </Box>
-            <Box mb={4}>
-                <Text>Watch how they respond as you resize your browser and as you scroll. If there isn't enough room on one side, the bubble may appear on the other side. Magic!</Text>
-            </Box>
-            <Box mb={4}>
-                <Text>How about <FloatyBox open="click" bubble={closableTooltip}><Wow>closable tooltips?</Wow></FloatyBox></Text>
-            </Box>
-            <Box mb={4}>
-                <Text>What about rolling your own <ColorPicker value={color} onChange={(color) => setColor(color)} /></Text>
-            </Box>
-            <Box mb={4} style={{overflow: 'auto'}}>
-                <Box width="170%">
-                    <Text>Look at how it positions itself correctly inside of scrollable containers: <FloatyBox open="click" bubble={tooltip}><Wow>click me!</Wow></FloatyBox></Text>
-                </Box>
-            </Box>
+            <IndexMdx />
         </Box>
     </Page>;
 };

--- a/packages/react-floatybox-docs/src/pages/indexMdx.mdx
+++ b/packages/react-floatybox-docs/src/pages/indexMdx.mdx
@@ -147,6 +147,15 @@ Sets the bubble's preferred perpendicular alignment.
 - When `side` is `"top"` or `"bottom"`, valid values are `"center"`, `"left"` or `"right"`.
 - When `side` is `"left"` or `"right"`, valid values are `"center"`, `"up"` or `"down"`.
 
+### flip
+
+```flow
+flip: boolean = false
+```
+
+Set to true to allow FloatyBox to flip the bubble to the opposite side of the anchor if there is not enough space to fit it on the preferred side.
+
+
 ### gap
 
 ```flow

--- a/packages/react-floatybox-docs/src/pages/indexMdx.mdx
+++ b/packages/react-floatybox-docs/src/pages/indexMdx.mdx
@@ -8,11 +8,12 @@ A React component for positioning floating components such as tooltips, dropdown
 - [Installation](#installation)
 - [Usage](#usage)
 - [Props](#props)
+- [Development](#development)
 
 ## Demo
 
-Here you can test out how different props behave. Click or hover over the bluen square.
-Try scrolling the square out of view while it's open, or drag the square around to see how it moves near the edges of the screen.
+Here you can test out how different props behave.
+Drag the square around, and try scrolling the square out of view to see how the various options make it respond when it's near the edges of the screen.
 
 <DragMe />
 
@@ -23,7 +24,7 @@ Try scrolling the square out of view while it's open, or drag the square around 
 - Handles all your bubble positioning
 - Avoids screen edges
 - Bubble size and position can be determined automatically, specified widths and heights not required
-- Built in support for positining of tails (those little pointy things at the bottom of tooltips)
+- Built in support for positioning of tails (those little pointy things at the bottom of tooltips)
 - Built in behaviour to open and close via hover or click, and to close via click-outside or ESC key
 - Can use its own state or can be controlled
 - Uses React portals via the [react-useportal](https://github.com/alex-cory/react-useportal) hook
@@ -143,7 +144,21 @@ Chooses the preferred side of the anchor that the bubble should appear on.
 align: string = "center"
 ```
 
-Sets the bubble's preferred perpendicular alignment.
+Sets the bubble's preferred alignment in relation to its tail.
+
+- When `side` is `"top"` or `"bottom"`, valid values are `"center"`, `"left"` or `"right"`.
+- When `side` is `"left"` or `"right"`, valid values are `"center"`, `"up"` or `"down"`.
+
+### alignInner
+
+```flow
+alignInner: string = "center"
+```
+
+Sets the tail's preferred alignment in relation to the anchor.
+
+When building things with small anchors and large bubbles, such as tooltips, this prop is usually best on its default "center" setting. But if your anchor is larger than your bubble then this alignment becomes more useful.
+
 - When `side` is `"top"` or `"bottom"`, valid values are `"center"`, `"left"` or `"right"`.
 - When `side` is `"left"` or `"right"`, valid values are `"center"`, `"up"` or `"down"`.
 
@@ -155,6 +170,21 @@ flip: boolean = false
 
 Set to true to allow FloatyBox to flip the bubble to the opposite side of the anchor if there is not enough space to fit it on the preferred side.
 
+### slide
+
+```flow
+slide: boolean = false
+```
+
+Set to true to allow FloatyBox to slide the bubble across the side of the anchor if there is not enough space to fit it at the preferred alignment.
+
+### trap
+
+```flow
+trap: boolean = false
+```
+
+Trap will prevent the bubble from ever leaving the screen.
 
 ### gap
 
@@ -238,11 +268,9 @@ If provided along with `isOpen`, this will be called when FloatyBox wants to cha
 
 ---
 
-## Todo
+## Development
 
-- Support for animations by adding an option to always render bubble
-- Option to auto close bubble when anchor moves off screen
-- Ease into new positions, rather than snapping directly
-- Allow `closeOnOutsideClick` and `closeOnEsc` to work when controlling state externally
-- Allow multiple floatyboxes to share a tooltip
-- Work out if its possible to not createReact portals until required when using react-useportal
+React-floatybox is written and maintained by [Damien Clarke](https://damienclarke.me/), with feedback from others at [92green](https://github.com/92green).
+All online library discussion happens over on [Github](https://github.com/92green/react-floatybox).
+
+I hope this library helps solve some React positioning problems for you. 🎉

--- a/packages/react-floatybox-docs/src/pages/indexMdx.mdx
+++ b/packages/react-floatybox-docs/src/pages/indexMdx.mdx
@@ -1,10 +1,22 @@
-# react-floatybox 🎈🎁🎉
+import {Box} from 'dcme-style/layout';
+import {Divider} from 'dcme-style/affordance';
+import {DragMe} from '../component/DragMe';
 
 A React component for positioning floating components such as tooltips, dropdowns, selects etc. Avoids screen edges!
 
-* **[See some examples - coming soon](#)**
+- [Features](#features)
+- [Installation](#installation)
+- [Usage](#usage)
+- [Props](#props)
+
+## Demo
+
+<DragMe />
+
+---
 
 ## Features
+
 - Handles all your bubble positioning
 - Avoids screen edges
 - Bubble size and position can be determined automatically, specified widths and heights not required
@@ -13,11 +25,15 @@ A React component for positioning floating components such as tooltips, dropdown
 - Can use its own state or can be controlled
 - Uses React portals via the [react-useportal](https://github.com/alex-cory/react-useportal) hook
 
+---
+
 ## Installation
 
-```
+```bash
 yarn add react-floatybox
 ```
+
+---
 
 ## Usage
 
@@ -73,12 +89,24 @@ const Basic = (props) => {
 };
 ```
 
-[See more examples - coming soon](#)
+---
 
 ## Props
 
+### children
+
+```flow
+children: React.Node
+```
+
+The React element that the bubble is tethered to, called the "anchor".
+It can handle click and hover events to control the open state of the bubble.
+
 ### bubble
-`({close, isOpen, tailProps}) => React.Node`
+
+```flow
+bubble: ({close, isOpen, tailProps}) => React.Node
+```
 
 A function for FloatyBox to call to render the floaty box.
 It's recommended you wrap this in a `useCallback` hook to improve rendering performance.
@@ -90,74 +118,105 @@ The function is passed an object with a few properties:
 | **isOpen**    | `boolean`                                     | A boolean indicating if the bubble is open.                                         |
 | **tailProps** | `{side: string, size: number, style: Object}` | An object that can be spread onto a tail component such as `react-floatybox/Point`. |
 
-
-### children
-`React.Node`
-
-The React element that the bubble is tethered to, called the "anchor".
-It can handle click and hover events to control the open state of the bubble.
-
 ### open
-`"click"|"hover" (optional)`
+
+```flow
+open?: "click"|"hover" // optional
+```
 
 If provided, this sets the kind of interaction that will open and close the bubble.
 
 ### side
-`"top"|"bottom"|"left"|"right", default = "top"`
+
+```flow
+side: "top"|"bottom"|"left"|"right" = "top"
+```
 
 Chooses the preferred side of the anchor that the bubble should appear on.
 
 ### align
-`string (optional), default = "center"`
+
+```flow
+align: string = "center"
+```
 
 Sets the bubble's preferred perpendicular alignment.
 - When `side` is `"top"` or `"bottom"`, valid values are `"center"`, `"left"` or `"right"`.
 - When `side` is `"left"` or `"right"`, valid values are `"center"`, `"up"` or `"down"`.
 
 ### gap
-`number (optional), default = 10`
+
+```flow
+gap: number = 10
+```
 
 The gap between the bubble and the anchor, in pixels.
 
 ### edge
-`number (optional), default = 10`
+
+```flow
+edge: number = 10
+```
 
 How close the bubble is allowed to be posiitioned near a screen edge, in pixels.
 
 ### zIndex
-`number (optional), default = 100`
+
+```flow
+zIndex: number = 100
+```
 
 The `zIndex` of the bubble element.
 
 ### closeOnOutsideClick
-`boolean (optional), default = true`
+
+```flow
+closeOnOutsideClick: boolean = true
+```
 
 A [react-useportal](https://github.com/alex-cory/react-useportal) option that lets the bubble close when you click outside of it.
 
 ### closeOnEsc
-`boolean (optional), default = true`
+
+```flow
+closeOnEsc: boolean = true
+```
 
 A [react-useportal](https://github.com/alex-cory/react-useportal) option that lets the bubble close when you press the escape key.
 
 ### tailSize
-`number (optional)`
+
+```flow
+tailSize?: number // optional
+```
 
 If a tail is used on your bubble, `tailSize` must be set so FloatyBox can adjust its positioning.
 
 ### wrap
-`React.Component (optional), default = "span"`
+
+```flow
+wrap: React.Component = "span"
+```
 
 The component that the FloatyBox anchor gets wrapped in.
 
 ### isOpen
-`boolean (optional)`
+
+```flow
+isOpen?: boolean // optional
+```
 
 If provided, FloatyBox won't keep its own state and will just be open when this boolean is `true`.
 
 ### onChange
-`(isOpen: boolean) => void (optional)`
+
+```flow
+onChange?: (isOpen: boolean) => void (optional)` // optional
+```
 
 If provided along with `isOpen`, this will be called when FloatyBox wants to change state.
+
+---
 
 ## Todo
 

--- a/packages/react-floatybox-docs/src/pages/indexMdx.mdx
+++ b/packages/react-floatybox-docs/src/pages/indexMdx.mdx
@@ -11,6 +11,9 @@ A React component for positioning floating components such as tooltips, dropdown
 
 ## Demo
 
+Here you can test out how different props behave. Click or hover over the bluen square.
+Try scrolling the square out of view while it's open, or drag the square around to see how it moves near the edges of the screen.
+
 <DragMe />
 
 ---
@@ -121,7 +124,7 @@ The function is passed an object with a few properties:
 ### open
 
 ```flow
-open?: "click"|"hover" // optional
+open?: "click"|"hover"|"always" // optional
 ```
 
 If provided, this sets the kind of interaction that will open and close the bubble.

--- a/packages/react-floatybox-docs/src/pages/indexMdx.mdx
+++ b/packages/react-floatybox-docs/src/pages/indexMdx.mdx
@@ -212,6 +212,14 @@ wrap: React.Component = "span"
 
 The component that the FloatyBox anchor gets wrapped in.
 
+### forceUpdate
+
+```flow
+forceUpdate: Array<any> = []
+```
+
+The forceUpdate prop allows you to force the bubble position to update. Pass it an array of values, and when any of these values change then the bubble position will be recalculated.
+
 ### isOpen
 
 ```flow
@@ -235,8 +243,6 @@ If provided along with `isOpen`, this will be called when FloatyBox wants to cha
 - Support for animations by adding an option to always render bubble
 - Option to auto close bubble when anchor moves off screen
 - Ease into new positions, rather than snapping directly
-- Add option to continually update, for when a FloatyBox is inside something that constantly moves
-- Add option to manually update, such as on prop change
 - Allow `closeOnOutsideClick` and `closeOnEsc` to work when controlling state externally
 - Allow multiple floatyboxes to share a tooltip
 - Work out if its possible to not createReact portals until required when using react-useportal

--- a/packages/react-floatybox-docs/yarn.lock
+++ b/packages/react-floatybox-docs/yarn.lock
@@ -1105,6 +1105,12 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
+"@babel/runtime@^7.1.5":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.8.3.tgz#0811944f73a6c926bb2ad35e918dcc1bfab279f1"
+  dependencies:
+    regenerator-runtime "^0.13.2"
+
 "@babel/runtime@^7.7.2":
   version "7.7.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.7.2.tgz#111a78002a5c25fc8e3361bedc9529c696b85a6a"
@@ -4059,6 +4065,13 @@ data-urls@^1.0.0:
 dataloader@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/dataloader/-/dataloader-1.4.0.tgz#bca11d867f5d3f1b9ed9f737bd15970c65dff5c8"
+
+dataparcels@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/dataparcels/-/dataparcels-1.0.2.tgz#49f78792c4b251f048c8ac89ab99e750c5d7e1b1"
+  dependencies:
+    "@babel/runtime" "^7.1.5"
+    unmutable "^0.46.1"
 
 date-now@^0.1.4:
   version "0.1.4"
@@ -10813,6 +10826,16 @@ rc@^1.0.1, rc@^1.1.6, rc@^1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
+react-dataparcels@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/react-dataparcels/-/react-dataparcels-1.0.2.tgz#4f866c91bebdf661d97889fb74cbccc53bcfe464"
+  dependencies:
+    "@babel/runtime" "^7.1.5"
+    dataparcels "^1.0.2"
+    is-promise "^2.1.0"
+    unmutable "^0.46.1"
+    use-debounce "^1.1.3"
+
 react-dev-utils@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/react-dev-utils/-/react-dev-utils-4.2.3.tgz#5b42d9ea58d5e9e017a2f57a40a8af408a3a46fb"
@@ -13176,6 +13199,15 @@ unmutable@^0.34.1:
     is-plain-object "^2.0.4"
     lodash.range "^3.2.0"
 
+unmutable@^0.46.1:
+  version "0.46.1"
+  resolved "https://registry.yarnpkg.com/unmutable/-/unmutable-0.46.1.tgz#af1e4c5bec4905bd8d288be45bd215f7e4d5ccb1"
+  dependencies:
+    "@babel/runtime" "^7.1.5"
+    fast-deep-equal "^1.0.0"
+    is-plain-object "^2.0.4"
+    lodash.range "^3.2.0"
+
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
@@ -13275,6 +13307,10 @@ url@^0.11.0:
   dependencies:
     punycode "1.3.2"
     querystring "0.2.0"
+
+use-debounce@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/use-debounce/-/use-debounce-1.1.3.tgz#08b76fd8cc9b107e0a6d6ee8bb6c5fe97a14732f"
 
 use@^3.1.0:
   version "3.1.1"

--- a/packages/react-floatybox/README.md
+++ b/packages/react-floatybox/README.md
@@ -154,6 +154,12 @@ If a tail is used on your bubble, `tailSize` must be set so FloatyBox can adjust
 
 The component that the FloatyBox anchor gets wrapped in.
 
+### forceUpdate
+
+`Array<any> (optional) default = []`
+
+The forceUpdate prop allows you to force the bubble position to update. Pass it an array of values, and when any of these values change then the bubble position will be recalculated.
+
 ### isOpen
 `boolean (optional)`
 
@@ -169,8 +175,6 @@ If provided along with `isOpen`, this will be called when FloatyBox wants to cha
 - Support for animations by adding an option to always render bubble
 - Option to auto close bubble when anchor moves off screen
 - Ease into new positions, rather than snapping directly
-- Add option to continually update, for when a FloatyBox is inside something that constantly moves
-- Add option to manually update, such as on prop change
 - Allow `closeOnOutsideClick` and `closeOnEsc` to work when controlling state externally
 - Allow multiple floatyboxes to share a tooltip
 - Work out if its possible to not createReact portals until required when using react-useportal

--- a/packages/react-floatybox/README.md
+++ b/packages/react-floatybox/README.md
@@ -114,6 +114,11 @@ Sets the bubble's preferred perpendicular alignment.
 - When `side` is `"top"` or `"bottom"`, valid values are `"center"`, `"left"` or `"right"`.
 - When `side` is `"left"` or `"right"`, valid values are `"center"`, `"up"` or `"down"`.
 
+### flip
+`boolean, default = false`
+
+Set to true to allow FloatyBox to flip the bubble to the opposite side of the anchor if there is not enough space to fit it on the preferred side.
+
 ### gap
 `number (optional), default = 10`
 

--- a/packages/react-floatybox/README.md
+++ b/packages/react-floatybox/README.md
@@ -69,7 +69,7 @@ const Basic = (props) => {
         return <div>I am a thing</div>;
     }, []);
 
-    return <FloatyBox open="click" align="lt" bubble={tooltip}>click me!</FloatyBox>;
+    return <FloatyBox open="click" side="top" align="left" bubble={tooltip}>click me!</FloatyBox>;
 };
 ```
 
@@ -114,23 +114,17 @@ It can handle click and hover events to control the open state of the bubble.
 
 If provided, this sets the kind of interaction that will open and close the bubble.
 
+#### side
+`"top"|"bottom"|"left"|"right", default = "top"`
+
+Chooses the preferred side of the anchor that the bubble should appear on.
+
 #### align
-`string (optional), default = "tc"`
+`string (optional), default = "center"`
 
-Sets the preferred positioning of the bubble relative to the anchor. Options are:
-
-- `tl` - top left
-- `tc` - top centre
-- `tr` - top right
-- `bl` - bottom left
-- `bc` - bottom centre
-- `br` - bottom right
-- `lt` - left top
-- `lc` - left centre
-- `lb` - left bottom
-- `rt` - right top
-- `rc` - right centre
-- `rb` - right bottom
+Sets the bubble's preferred perpendicular alignment.
+- When `side` is `"top"` or `"bottom"`, valid values are `"center"`, `"left"` or `"right"`.
+- When `side` is `"left"` or `"right"`, valid values are `"center"`, `"up"` or `"down"`.
 
 ### gap
 `number (optional), default = 10`
@@ -183,5 +177,7 @@ If provided along with `isOpen`, this will be called when FloatyBox wants to cha
 - Option to auto close bubble when anchor moves off screen
 - Ease into new positions, rather than snapping directly
 - Add option to continually update, for when a FloatyBox is inside something that constantly moves
+- Add option to manually update, such as on prop change
 - Allow `closeOnOutsideClick` and `closeOnEsc` to work when controlling state externally
+- Allow multiple floatyboxes to share a tooltip
 - Work out if its possible to not createReact portals until required when using react-useportal

--- a/packages/react-floatybox/README.md
+++ b/packages/react-floatybox/README.md
@@ -77,49 +77,37 @@ const Basic = (props) => {
 
 ## Props
 
-### Required
-
-#### bubble
+### bubble
 `({close, isOpen, tailProps}) => React.Node`
 
 A function for FloatyBox to call to render the floaty box.
 It's recommended you wrap this in a `useCallback` hook to improve rendering performance.
 The function is passed an object with a few properties:
 
-##### close
-`() => void`
+|               |                                               |                                                                                     |
+| ------------- | --------------------------------------------- | ----------------------------------------------------------------------------------- |
+| **close**     | `() => void`                                  | A function that can be called from inside the bubble to close itself.               |
+| **isOpen**    | `boolean`                                     | A boolean indicating if the bubble is open.                                         |
+| **tailProps** | `{side: string, size: number, style: Object}` | An object that can be spread onto a tail component such as `react-floatybox/Point`. |
 
-A function that can be called from inside the bubble to close itself.
 
-##### isOpen
-`boolean`
-
-A boolean indicating if the bubble is open.
-
-##### tailProps
-`{side: string, size: number, style: Object}`
-
-An object that can be spread onto a tail component such as `react-floatybox/Point`.
-
-#### children
+### children
 `React.Node`
 
 The React element that the bubble is tethered to, called the "anchor".
 It can handle click and hover events to control the open state of the bubble.
 
-### Optional
-
-#### open
+### open
 `"click"|"hover" (optional)`
 
 If provided, this sets the kind of interaction that will open and close the bubble.
 
-#### side
+### side
 `"top"|"bottom"|"left"|"right", default = "top"`
 
 Chooses the preferred side of the anchor that the bubble should appear on.
 
-#### align
+### align
 `string (optional), default = "center"`
 
 Sets the bubble's preferred perpendicular alignment.

--- a/packages/react-floatybox/README.md
+++ b/packages/react-floatybox/README.md
@@ -4,11 +4,17 @@ A React component for positioning floating components such as tooltips, dropdown
 
 * **[See some examples - coming soon](#)**
 
+- [Features](#features)
+- [Installation](#installation)
+- [Usage](#usage)
+- [Props](#props)
+- [Development](#development)
+
 ## Features
 - Handles all your bubble positioning
 - Avoids screen edges
 - Bubble size and position can be determined automatically, specified widths and heights not required
-- Built in support for positining of tails (those little pointy things at the bottom of tooltips)
+- Built in support for positioning of tails (those little pointy things at the bottom of tooltips)
 - Built in behaviour to open and close via hover or click, and to close via click-outside or ESC key
 - Can use its own state or can be controlled
 - Uses React portals via the [react-useportal](https://github.com/alex-cory/react-useportal) hook
@@ -77,8 +83,20 @@ const Basic = (props) => {
 
 ## Props
 
+### children
+
+```flow
+children: React.Node
+```
+
+The React element that the bubble is tethered to, called the "anchor".
+It can handle click and hover events to control the open state of the bubble.
+
 ### bubble
-`({close, isOpen, tailProps}) => React.Node`
+
+```flow
+bubble: ({close, isOpen, tailProps}) => React.Node
+```
 
 A function for FloatyBox to call to render the floaty box.
 It's recommended you wrap this in a `useCallback` hook to improve rendering performance.
@@ -90,91 +108,153 @@ The function is passed an object with a few properties:
 | **isOpen**    | `boolean`                                     | A boolean indicating if the bubble is open.                                         |
 | **tailProps** | `{side: string, size: number, style: Object}` | An object that can be spread onto a tail component such as `react-floatybox/Point`. |
 
-
-### children
-`React.Node`
-
-The React element that the bubble is tethered to, called the "anchor".
-It can handle click and hover events to control the open state of the bubble.
-
 ### open
-`"click"|"hover"|"always" (optional)`
+
+```flow
+open?: "click"|"hover"|"always" // optional
+```
 
 If provided, this sets the kind of interaction that will open and close the bubble.
 
 ### side
-`"top"|"bottom"|"left"|"right", default = "top"`
+
+```flow
+side: "top"|"bottom"|"left"|"right" = "top"
+```
 
 Chooses the preferred side of the anchor that the bubble should appear on.
 
 ### align
-`string (optional), default = "center"`
 
-Sets the bubble's preferred perpendicular alignment.
+```flow
+align: string = "center"
+```
+
+Sets the bubble's preferred alignment in relation to its tail.
+
+- When `side` is `"top"` or `"bottom"`, valid values are `"center"`, `"left"` or `"right"`.
+- When `side` is `"left"` or `"right"`, valid values are `"center"`, `"up"` or `"down"`.
+
+### alignInner
+
+```flow
+alignInner: string = "center"
+```
+
+Sets the tail's preferred alignment in relation to the anchor.
+
+When building things with small anchors and large bubbles, such as tooltips, this prop is usually best on its default "center" setting. But if your anchor is larger than your bubble then this alignment becomes more useful.
+
 - When `side` is `"top"` or `"bottom"`, valid values are `"center"`, `"left"` or `"right"`.
 - When `side` is `"left"` or `"right"`, valid values are `"center"`, `"up"` or `"down"`.
 
 ### flip
-`boolean, default = false`
+
+```flow
+flip: boolean = false
+```
 
 Set to true to allow FloatyBox to flip the bubble to the opposite side of the anchor if there is not enough space to fit it on the preferred side.
 
+### slide
+
+```flow
+slide: boolean = false
+```
+
+Set to true to allow FloatyBox to slide the bubble across the side of the anchor if there is not enough space to fit it at the preferred alignment.
+
+### trap
+
+```flow
+trap: boolean = false
+```
+
+Trap will prevent the bubble from ever leaving the screen.
+
 ### gap
-`number (optional), default = 10`
+
+```flow
+gap: number = 10
+```
 
 The gap between the bubble and the anchor, in pixels.
 
 ### edge
-`number (optional), default = 10`
+
+```flow
+edge: number = 10
+```
 
 How close the bubble is allowed to be posiitioned near a screen edge, in pixels.
 
 ### zIndex
-`number (optional), default = 100`
+
+```flow
+zIndex: number = 100
+```
 
 The `zIndex` of the bubble element.
 
 ### closeOnOutsideClick
-`boolean (optional), default = true`
+
+```flow
+closeOnOutsideClick: boolean = true
+```
 
 A [react-useportal](https://github.com/alex-cory/react-useportal) option that lets the bubble close when you click outside of it.
 
 ### closeOnEsc
-`boolean (optional), default = true`
+
+```flow
+closeOnEsc: boolean = true
+```
 
 A [react-useportal](https://github.com/alex-cory/react-useportal) option that lets the bubble close when you press the escape key.
 
 ### tailSize
-`number (optional)`
+
+```flow
+tailSize?: number // optional
+```
 
 If a tail is used on your bubble, `tailSize` must be set so FloatyBox can adjust its positioning.
 
 ### wrap
-`React.Component (optional), default = "span"`
+
+```flow
+wrap: React.Component = "span"
+```
 
 The component that the FloatyBox anchor gets wrapped in.
 
 ### forceUpdate
 
-`Array<any> (optional) default = []`
+```flow
+forceUpdate: Array<any> = []
+```
 
 The forceUpdate prop allows you to force the bubble position to update. Pass it an array of values, and when any of these values change then the bubble position will be recalculated.
 
 ### isOpen
-`boolean (optional)`
+
+```flow
+isOpen?: boolean // optional
+```
 
 If provided, FloatyBox won't keep its own state and will just be open when this boolean is `true`.
 
 ### onChange
-`(isOpen: boolean) => void (optional)`
+
+```flow
+onChange?: (isOpen: boolean) => void (optional)` // optional
+```
 
 If provided along with `isOpen`, this will be called when FloatyBox wants to change state.
 
-## Todo
+## Development
 
-- Support for animations by adding an option to always render bubble
-- Option to auto close bubble when anchor moves off screen
-- Ease into new positions, rather than snapping directly
-- Allow `closeOnOutsideClick` and `closeOnEsc` to work when controlling state externally
-- Allow multiple floatyboxes to share a tooltip
-- Work out if its possible to not createReact portals until required when using react-useportal
+React-floatybox is written and maintained by [Damien Clarke](https://damienclarke.me/), with feedback from others at [92green](https://github.com/92green).
+All online library discussion happens over on [Github](https://github.com/92green/react-floatybox).
+
+I hope this library helps solve some React positioning problems for you. 🎉

--- a/packages/react-floatybox/README.md
+++ b/packages/react-floatybox/README.md
@@ -98,7 +98,7 @@ The React element that the bubble is tethered to, called the "anchor".
 It can handle click and hover events to control the open state of the bubble.
 
 ### open
-`"click"|"hover" (optional)`
+`"click"|"hover"|"always" (optional)`
 
 If provided, this sets the kind of interaction that will open and close the bubble.
 

--- a/packages/react-floatybox/src/FloatyBox.jsx
+++ b/packages/react-floatybox/src/FloatyBox.jsx
@@ -35,6 +35,8 @@ type Props = {
     open?: "click"|"hover"|"always",
     closeOnOutsideClick?: boolean,
     closeOnEsc?: boolean,
+    // update control
+    forceUpdate: any[],
     // controlled state
     isOpen?: boolean,
     onChange?: (isOpen: boolean) => void
@@ -85,7 +87,14 @@ const FloatyBox = (props: Props): Node => {
 
     let [windowWidth, windowHeight] = useWindowDimensions();
 
-    let updateElementRectWhenChanged = [windowWidth, windowHeight, portal.isOpen, props.open === 'always'];
+    let updateElementRectWhenChanged = [
+        windowWidth,
+        windowHeight,
+        portal.isOpen,
+        props.open === 'always',
+        ...props.forceUpdate
+    ];
+
     let [anchorRect] = useElementRect(portal.ref, updateElementRectWhenChanged);
 
     let {flip, gap, edge, tailSize} = props;
@@ -111,7 +120,7 @@ const FloatyBox = (props: Props): Node => {
 
     let {bubbleStyle, tailStyle, realSide} = useMemo(
         () => getFloatyStyle(params),
-        Object.keys(params).map(key => params[key])
+        Object.keys(params).map(key => params[key]).concat(props.forceUpdate)
     );
 
     // floatybox can be controlled
@@ -183,7 +192,8 @@ FloatyBox.defaultProps = {
     edge: 10,
     wrap: 'span',
     zIndex: 100,
-    tailSize: 0
+    tailSize: 0,
+    forceUpdate: []
 };
 
 export default FloatyBox;

--- a/packages/react-floatybox/src/FloatyBox.jsx
+++ b/packages/react-floatybox/src/FloatyBox.jsx
@@ -20,7 +20,8 @@ type Props = {
     // element thunks
     bubble: (bubbleParams: BubbleParams) => Node,
     // positioning
-    align: string,
+    side: "top"|"bottom"|"left"|"right",
+    align: "up"|"down"|"left"|"right"|"center",
     gap: number,
     edge: number,
     zIndex: number,
@@ -50,8 +51,17 @@ type BubbleParams = {
 
 const FloatyBox = (props: Props): Node => {
 
-    let [side, align] = props.align.split('');
+    let getSideAlignLetter = (str: string): string => {
+        str = str[0];
+        if(str === 'u') return 't';
+        if(str === 'd') return 'b';
+        return str;
+    };
+
     let {gap, edge, tailSize} = props;
+    let side = getSideAlignLetter(props.side);
+    let align = getSideAlignLetter(props.align);
+
 
     let isControlled = typeof props.isOpen === 'boolean';
 
@@ -166,7 +176,8 @@ const FloatyBox = (props: Props): Node => {
 };
 
 FloatyBox.defaultProps = {
-    align: 'tc',
+    side: 'top',
+    align: 'center',
     gap: 10,
     edge: 10,
     wrap: 'span',

--- a/packages/react-floatybox/src/FloatyBox.jsx
+++ b/packages/react-floatybox/src/FloatyBox.jsx
@@ -13,6 +13,10 @@ import {useMemo} from 'react';
 import usePortal from 'react-useportal';
 import useRealDimensions from 'react-use-real-dimensions';
 
+//
+// floatybox component
+//
+
 type Props = {
     // components
     children: Node,
@@ -22,6 +26,7 @@ type Props = {
     // positioning
     side: "top"|"bottom"|"left"|"right",
     align: "up"|"down"|"left"|"right"|"center",
+    flip: boolean,
     gap: number,
     edge: number,
     zIndex: number,
@@ -58,11 +63,6 @@ const FloatyBox = (props: Props): Node => {
         return str;
     };
 
-    let {gap, edge, tailSize} = props;
-    let side = getSideAlignLetter(props.side);
-    let align = getSideAlignLetter(props.align);
-
-
     let isControlled = typeof props.isOpen === 'boolean';
 
     // set up element measurement
@@ -88,6 +88,10 @@ const FloatyBox = (props: Props): Node => {
     let updateElementRectWhenChanged = [windowWidth, windowHeight, portal.isOpen, props.open === 'always'];
     let [anchorRect] = useElementRect(portal.ref, updateElementRectWhenChanged);
 
+    let {flip, gap, edge, tailSize} = props;
+    let side = getSideAlignLetter(props.side);
+    let align = getSideAlignLetter(props.align);
+
     let params = {
         bubbleWidth,
         bubbleHeight,
@@ -101,7 +105,8 @@ const FloatyBox = (props: Props): Node => {
         align,
         gap,
         edge,
-        tailSize
+        tailSize,
+        flip
     };
 
     let {bubbleStyle, tailStyle, realSide} = useMemo(
@@ -173,6 +178,7 @@ const FloatyBox = (props: Props): Node => {
 FloatyBox.defaultProps = {
     side: 'top',
     align: 'center',
+    flip: false,
     gap: 10,
     edge: 10,
     wrap: 'span',
@@ -182,13 +188,41 @@ FloatyBox.defaultProps = {
 
 export default FloatyBox;
 
+//
 // positioning maths
+//
 
-let lerp = (a, b, amount) => a + (b - a) * amount;
-let clamp = (x, min, max) => Math.min(Math.max(x, min), max);
-let inRange = (x, min, max) => x >= min && x <= max;
+const lerp = (a, b, amount) => a + (b - a) * amount;
+const clamp = (x, min, max) => Math.min(Math.max(x, min), max);
+const inRange = (x, min, max) => x >= min && x <= max;
 
-const getFloatyStyle = (params) => {
+const X_AXIS = {l: 0, c: 0.5, r: 1};
+const Y_AXIS = {t: 0, c: 0.5, b: 1};
+const FLIP_AXIS = {l: 'r', r: 'l', t: 'b', b: 't'};
+
+type GetFloatyStyleParams = {
+    bubbleWidth?: number,
+    bubbleHeight?: number,
+    windowWidth: number,
+    windowHeight: number,
+    anchorTop: number,
+    anchorBottom: number,
+    anchorLeft: number,
+    anchorRight: number,
+    side: string,
+    align: string,
+    gap: number,
+    edge: number,
+    tailSize: number
+};
+
+type GetFloatyStyleResult = {
+    bubbleStyle: any,
+    tailStyle: any,
+    realSide?: string
+};
+
+const getFloatyStyle = (params: GetFloatyStyleParams): GetFloatyStyleResult => {
     let {
         bubbleWidth,
         bubbleHeight,
@@ -202,11 +236,12 @@ const getFloatyStyle = (params) => {
         align,
         gap,
         edge,
-        tailSize
+        tailSize,
+        flip
     } = params;
 
     // bubble measurement not yet taken, return blank styles for measuring the bubble with
-    if(params.bubbleHeight === undefined || params.bubbleWidth === undefined) {
+    if(bubbleHeight === undefined || bubbleWidth === undefined) {
         return {
             bubbleStyle: {},
             tailStyle: {
@@ -215,68 +250,33 @@ const getFloatyStyle = (params) => {
         };
     }
 
-    let xAxis = {l: 0, c: 0.5, r: 1};
-    let yAxis = {t: 0, c: 0.5, b: 1};
-    let flip = {l: 'r', r: 'l', t: 'b', b: 't'};
+    let xResult = positionOnAxis(
+        side,
+        align,
+        gap,
+        edge,
+        tailSize,
+        X_AXIS,
+        anchorLeft,
+        anchorRight,
+        bubbleWidth,
+        windowWidth,
+        flip
+    );
 
-    let calc = (axis, anchorStart, anchorEnd, bubbleSize, windowSize) => {
-
-        let anchorSize = anchorEnd - anchorStart;
-        let maxEdge = windowSize - bubbleSize - edge;
-
-        // if this is the main axis (the first letter of props.align)
-        // then do this bit
-        if(axis[side] !== undefined) {
-            // set position to either the close or far side of the bubble
-            let startPos = anchorStart - bubbleSize - gap;
-            let endPos = anchorEnd + gap;
-            let pos = lerp(startPos, endPos, axis[side]);
-
-            // flip side if there isnt enough room on preferred side
-            if(pos < edge || pos + bubbleSize > windowSize - edge) {
-                side = flip[side];
-                pos = lerp(startPos, endPos, axis[side]);
-            }
-
-            // clamp position so the bubble doesnt get too close to screen edges
-            let clampedPos = clamp(pos, edge, maxEdge);
-
-            // position tail
-            let tailHide = !inRange(pos, edge, maxEdge);
-            let tail = lerp(bubbleSize - 1, -tailSize + 1, axis[side]);
-
-            return {
-                pos: clampedPos,
-                tail,
-                tailHide,
-                side
-            };
-        }
-
-        // ...or else this is the cross axis (the second letter of props.align)
-        let pos = lerp(anchorEnd - bubbleSize + 1, anchorStart, axis[align]);
-        let tailSizeDiff = (tailSize - anchorSize) * 0.5;
-
-        // clamp position so there is always enough room for a tail
-        let clampedPos = clamp(pos, anchorEnd - bubbleSize + tailSizeDiff, anchorStart - tailSizeDiff);
-
-        // clamp position again so the bubble doesnt get too close to screen edges
-        clampedPos = clamp(clampedPos, edge, maxEdge);
-
-        // position tail
-        let tail = anchorStart - clampedPos - tailSizeDiff;
-        let tailHide = !inRange(tail, 0, bubbleSize + tailSize);
-
-        return {
-            pos: clampedPos,
-            tail,
-            tailHide,
-            side: undefined
-        };
-    };
-
-    let xResult = calc(xAxis, anchorLeft, anchorRight, bubbleWidth, windowWidth);
-    let yResult = calc(yAxis, anchorTop, anchorBottom, bubbleHeight, windowHeight);
+    let yResult = positionOnAxis(
+        side,
+        align,
+        gap,
+        edge,
+        tailSize,
+        Y_AXIS,
+        anchorTop,
+        anchorBottom,
+        bubbleHeight,
+        windowHeight,
+        flip
+    );
 
     return {
         bubbleStyle: {
@@ -291,9 +291,93 @@ const getFloatyStyle = (params) => {
             left: `${xResult.tail.toFixed()}px`,
             top: `${yResult.tail.toFixed()}px`
         },
+        // $FlowFixMe - one of xResult.side or yResult.side will be a string
         realSide: xResult.side || yResult.side
     };
 };
+
+type PositionOnAxisResult = {
+    pos: number,
+    tail: number,
+    tailHide: boolean,
+    side: ?string
+};
+
+// exported only for tests
+// do not use this directly,
+// this is not part of the public API
+// and is liable to change at any time
+export const positionOnAxis = (
+    side: string,
+    align: string,
+    gap: number,
+    edge: number,
+    tailSize: number,
+    axis: any,
+    anchorStart: number,
+    anchorEnd: number,
+    bubbleSize: number,
+    windowSize: number,
+    flip: boolean
+): PositionOnAxisResult => {
+
+    let anchorSize = anchorEnd - anchorStart;
+    let maxEdge = windowSize - bubbleSize - edge;
+
+    // if this is the main axis (the first letter of props.align)
+    // then do this bit
+    if(axis[side] !== undefined) {
+        // set position to either the close or far side of the bubble
+        let startPos = anchorStart - bubbleSize - gap;
+        let endPos = anchorEnd + gap;
+        let pos = lerp(startPos, endPos, axis[side]);
+
+        // flip side if there isnt enough room on preferred side
+        if(flip && pos < edge || pos + bubbleSize > windowSize - edge) {
+            side = FLIP_AXIS[side];
+            pos = lerp(startPos, endPos, axis[side]);
+        }
+
+        // clamp position so the bubble doesnt get too close to screen edges
+        let clampedPos = clamp(pos, edge, maxEdge);
+
+        // position tail
+        let tailHide = !inRange(pos, edge, maxEdge);
+        let tail = lerp(bubbleSize - 1, -tailSize + 1, axis[side]);
+
+        return {
+            pos: clampedPos,
+            tail,
+            tailHide,
+            side
+        };
+    }
+
+    // ...or else this is the cross axis (the second letter of props.align)
+    let pos = lerp(anchorEnd - bubbleSize + 1, anchorStart, axis[align]);
+    let tailSizeDiff = (tailSize - anchorSize) * 0.5;
+
+    // clamp position so there is always enough room for a tail
+    let clampedPos = clamp(pos, anchorEnd - bubbleSize + tailSizeDiff, anchorStart - tailSizeDiff);
+
+    // clamp position again so the bubble doesnt get too close to screen edges
+    clampedPos = clamp(clampedPos, edge, maxEdge);
+
+    // position tail
+    let tail = anchorStart - clampedPos - tailSizeDiff;
+    let tailHide = !inRange(tail, 0, bubbleSize + tailSize);
+
+    return {
+        pos: clampedPos,
+        tail,
+        tailHide,
+        side: undefined
+    };
+};
+
+//
+// hooks and utils
+//
 
 // floatybox can be controlled
 // if so, keep usePortal's state in sync

--- a/packages/react-floatybox/src/FloatyBox.jsx
+++ b/packages/react-floatybox/src/FloatyBox.jsx
@@ -26,7 +26,10 @@ type Props = {
     // positioning
     side: "top"|"bottom"|"left"|"right",
     align: "up"|"down"|"left"|"right"|"center",
+    alignInner: "up"|"down"|"left"|"right"|"center",
     flip: boolean,
+    slide: boolean,
+    trap: boolean,
     gap: number,
     edge: number,
     zIndex: number,
@@ -97,9 +100,10 @@ const FloatyBox = (props: Props): Node => {
 
     let [anchorRect] = useElementRect(portal.ref, updateElementRectWhenChanged);
 
-    let {flip, gap, edge, tailSize} = props;
+    let {flip, slide, trap, gap, edge, tailSize} = props;
     let side = getSideAlignLetter(props.side);
     let align = getSideAlignLetter(props.align);
+    let alignInner = getSideAlignLetter(props.alignInner);
 
     let params = {
         bubbleWidth,
@@ -112,10 +116,13 @@ const FloatyBox = (props: Props): Node => {
         anchorRight: anchorRect ? anchorRect.right : 0,
         side,
         align,
+        alignInner,
         gap,
         edge,
         tailSize,
-        flip
+        flip,
+        slide,
+        trap
     };
 
     let {bubbleStyle, tailStyle, realSide} = useMemo(
@@ -187,9 +194,12 @@ const FloatyBox = (props: Props): Node => {
 FloatyBox.defaultProps = {
     side: 'top',
     align: 'center',
+    alignInner: 'center',
     flip: false,
-    gap: 10,
-    edge: 10,
+    slide: false,
+    trap: false,
+    gap: 0,
+    edge: 0,
     wrap: 'span',
     zIndex: 100,
     tailSize: 0,
@@ -204,7 +214,6 @@ export default FloatyBox;
 
 const lerp = (a, b, amount) => a + (b - a) * amount;
 const clamp = (x, min, max) => Math.min(Math.max(x, min), max);
-const inRange = (x, min, max) => x >= min && x <= max;
 
 const X_AXIS = {l: 0, c: 0.5, r: 1};
 const Y_AXIS = {t: 0, c: 0.5, b: 1};
@@ -221,9 +230,13 @@ type GetFloatyStyleParams = {
     anchorRight: number,
     side: string,
     align: string,
+    alignInner: string,
     gap: number,
     edge: number,
-    tailSize: number
+    tailSize: number,
+    flip: boolean,
+    slide: boolean,
+    trap: boolean
 };
 
 type GetFloatyStyleResult = {
@@ -244,10 +257,13 @@ const getFloatyStyle = (params: GetFloatyStyleParams): GetFloatyStyleResult => {
         anchorRight,
         side,
         align,
+        alignInner,
         gap,
         edge,
         tailSize,
-        flip
+        flip,
+        slide,
+        trap
     } = params;
 
     // bubble measurement not yet taken, return blank styles for measuring the bubble with
@@ -263,6 +279,7 @@ const getFloatyStyle = (params: GetFloatyStyleParams): GetFloatyStyleResult => {
     let xResult = positionOnAxis(
         side,
         align,
+        alignInner,
         gap,
         edge,
         tailSize,
@@ -271,12 +288,15 @@ const getFloatyStyle = (params: GetFloatyStyleParams): GetFloatyStyleResult => {
         anchorRight,
         bubbleWidth,
         windowWidth,
-        flip
+        flip,
+        slide,
+        trap
     );
 
     let yResult = positionOnAxis(
         side,
         align,
+        alignInner,
         gap,
         edge,
         tailSize,
@@ -285,7 +305,9 @@ const getFloatyStyle = (params: GetFloatyStyleParams): GetFloatyStyleResult => {
         anchorBottom,
         bubbleHeight,
         windowHeight,
-        flip
+        flip,
+        slide,
+        trap
     );
 
     return {
@@ -320,6 +342,7 @@ type PositionOnAxisResult = {
 export const positionOnAxis = (
     side: string,
     align: string,
+    alignInner: string,
     gap: number,
     edge: number,
     tailSize: number,
@@ -328,57 +351,76 @@ export const positionOnAxis = (
     anchorEnd: number,
     bubbleSize: number,
     windowSize: number,
-    flip: boolean
+    flip: boolean,
+    slide: boolean,
+    trap: boolean
 ): PositionOnAxisResult => {
 
-    let anchorSize = anchorEnd - anchorStart;
-    let maxEdge = windowSize - bubbleSize - edge;
-
-    // if this is the main axis (the first letter of props.align)
+    // if this is the main axis a.k.a. props.side
     // then do this bit
     if(axis[side] !== undefined) {
-        // set position to either the close or far side of the bubble
+        // set position to the preferred side of the bubble
         let startPos = anchorStart - bubbleSize - gap;
         let endPos = anchorEnd + gap;
         let pos = lerp(startPos, endPos, axis[side]);
 
-        // flip side if there isnt enough room on preferred side
-        if(flip && pos < edge || pos + bubbleSize > windowSize - edge) {
-            side = FLIP_AXIS[side];
-            pos = lerp(startPos, endPos, axis[side]);
+        // if using flip, flip side if there isnt enough room on preferred side
+        if(flip && (pos < edge || pos + bubbleSize > windowSize - edge)) {
+            pos = lerp(endPos, startPos, axis[side]);
         }
 
-        // clamp position so the bubble doesnt get too close to screen edges
-        let clampedPos = clamp(pos, edge, maxEdge);
+        // if using trap, clamp position so the bubble doesnt leave screen edges
+        if(trap) {
+            pos = clamp(pos, edge, windowSize - bubbleSize - edge);
+        }
+
+        // if new positioning of bubble has made it flip sides, tell the tail to swap sides
+        let midBubble = pos + bubbleSize * 0.5;
+        let midAnchor = anchorStart + (anchorEnd - anchorStart) * 0.5;
+        if(midBubble > midAnchor === (axis[side] === 0)) {
+            side = FLIP_AXIS[side];
+        }
 
         // position tail
-        let tailHide = !inRange(pos, edge, maxEdge);
         let tail = lerp(bubbleSize - 1, -tailSize + 1, axis[side]);
 
         return {
-            pos: clampedPos,
+            pos,
             tail,
-            tailHide,
+            tailHide: false,
             side
         };
     }
 
-    // ...or else this is the cross axis (the second letter of props.align)
-    let pos = lerp(anchorEnd - bubbleSize + 1, anchorStart, axis[align]);
-    let tailSizeDiff = (tailSize - anchorSize) * 0.5;
+    // ...or else this is the cross axis a.k.a. props.align
+    let halfTail = tailSize * 0.5;
+    let innerPos = lerp(anchorStart + halfTail, anchorEnd - halfTail, axis[alignInner]);
+    let minPos = innerPos - bubbleSize + halfTail;
+    let maxPos = innerPos - halfTail;
+    let pos = lerp(minPos, maxPos, axis[align]);
 
-    // clamp position so there is always enough room for a tail
-    let clampedPos = clamp(pos, anchorEnd - bubbleSize + tailSizeDiff, anchorStart - tailSizeDiff);
+    // if using slide, slide bubble along if too close to screen edges
+    let tailHide = false;
+    if(slide || trap) {
+        pos = clamp(pos, edge, windowSize - bubbleSize - edge);
 
-    // clamp position again so the bubble doesnt get too close to screen edges
-    clampedPos = clamp(clampedPos, edge, maxEdge);
+        // find out if the tail has detached
+        // and if trap is used, hide the tail
+        // or if trap is not used, move the bubble back so its attached again
+        if(pos < minPos || pos > maxPos) {
+            if(trap) {
+                tailHide = true;
+            } else {
+                pos = clamp(pos, minPos, maxPos);
+            }
+        }
+    }
 
     // position tail
-    let tail = anchorStart - clampedPos - tailSizeDiff;
-    let tailHide = !inRange(tail, 0, bubbleSize + tailSize);
+    let tail = (innerPos - halfTail) - pos;
 
     return {
-        pos: clampedPos,
+        pos,
         tail,
         tailHide,
         side: undefined


### PR DESCRIPTION
Contains #5 #6 #7 #8 #9 and #10 

- **BREAKING CHANGE** single `align` prop has been replaced with a `side` prop and an `align` prop, to allow each prop to have individual defaults, and also to better manage confusion once the slightly advanced concept of `innerAlign` is introduced.
- **BREAKING CHANGE** default behaviour does not flip
- **BREAKING CHANGE** default behaviour now doesn't trap the bubble on screen
- **BREAKING CHANGE** default props `edge` changed from 10 to 0.
- **BREAKING CHANGE** default props `gap` changed from 10 to 0.
  - Tooltips probably want it, drop downs may or may not
- Added `open="always"` option which always renders the bubble
- Added `alignInner` to align the tail against the anchor
- Added `trap` to toggle whether the bubble is always trapped on screen or if its allowed to slide off
- Added `flip` and `slide` as options to toggle those screen-edge avoiding behaviours
- Added `forceUpdate` option to force update and reposition bubble on prop change